### PR TITLE
Add more linters support on Linux

### DIFF
--- a/linters
+++ b/linters
@@ -26,7 +26,17 @@ if [ -f .markdownlint.yml ]; then
   echo "Checking Markdown..."
 
   if ! type -P markdownlint-cli2 &>/dev/null; then
-    brew install markdownlint-cli2
+    if uname -s | grep Darwin &>/dev/null; then
+      brew install markdownlint-cli2
+    elif type -P npm &>/dev/null; then
+      if type -P npm | grep "${HOME}" &>/dev/null; then
+        SUDO=""
+      else
+        SUDO="sudo"
+      fi
+
+      ${SUDO} npm install -g markdownlint-cli2
+    fi
   fi
 
   markdownlint-cli2 "**/*.md" "#.*" "#**/vendor/**" "#**/node_modules/**" "#**/Libraries/**" "#**/Pods/**"

--- a/linters
+++ b/linters
@@ -9,7 +9,14 @@ if [[ -e ${yml_files[0]} ]] || [[ -e ${yaml_files[0]} ]]; then
   echo "Checking GitHub Actions workflow files..."
 
   if ! type -P actionlint &>/dev/null; then
-    brew install actionlint
+    if uname -s | grep Darwin &>/dev/null; then
+      brew install actionlint
+    else
+      tarball_url="$(curl -s https://api.github.com/repos/rhysd/actionlint/releases/latest | grep -E "browser_download_url.*linux_amd64" | cut -d\" -f4)"
+      curl -sSL "${tarball_url}" | tar zxf - actionlint
+      chmod 0755 actionlint
+      sudo mv actionlint /usr/local/bin/
+    fi
   fi
 
   actionlint


### PR DESCRIPTION
# Summary

Automatically install linters on Linux instead of crashing because of `brew command not found`.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
