### PR TITLE
deploy: add --create_ami_only flag

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -45,6 +45,7 @@ begin
     opts.separator('options')
 
     opts.on('--ami ami', String)
+    opts.on('--create_ami_only')
     opts.on('--environment environment', String)
     opts.on('--instance instance', String)
     opts.on('--type instance_type', String)
@@ -194,6 +195,11 @@ begin
     )
     ami_id = ami.image_id
     puts("Image creation completed for #{ami.image_id}.")
+
+    if options[:create_ami_only]
+      puts('Exiting now as --create_ami_only was supplied.')
+      exit
+    end
   end
 
   # find auto scaling group


### PR DESCRIPTION
# Summary

Add ability to make `deploy.rb` exit right after AMI creation and skip the rest of deployment.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
