### PR TITLE
docker: add default ubuntu user to citools group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,12 @@ RUN ssm_arch="$(test "$(uname -m)" = "x86_64" && echo "64bit" || echo "arm64")" 
 RUN useradd -m -s /bin/bash citools && echo 'citools ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && adduser ubuntu citools
 
 # Clone the soup repository
-USER citools
-WORKDIR /home/citools
-RUN git clone https://github.com/Cloud-Officer/ci-tools.git
+ADD https://github.com/Cloud-Officer/ci-tools.git /home/citools/ci-tools
 
 # Install ci-tools dependencies and create a symlink
 USER root
 WORKDIR /home/citools/ci-tools
-RUN bundle install && ln -s "/home/citools/ci-tools/brew-resources.rb" "/usr/local/bin/brew-resources" && ln -s "/home/citools/ci-tools//cycle-keys.rb" "/usr/local/bin/cycle-keys" && ln -s "/home/citools/ci-tools/deploy.rb" "/usr/local/bin/deploy" && ln -s "/home/citools/ci-tools/encrypt-logs.rb" "/usr/local/bin/encrypt-logs" && ln -s "/home/citools/ci-tools/generate-codeowners" "/usr/local/bin/generate-codeowners" && ln -s "/home/citools/ci-tools/linters" "/usr/local/bin/linters" && ln -s "/home/citools/ci-tools/ssh-jump" "/usr/local/bin/ssh-jump" && ln -s "/home/citools/ci-tools/ssm-jump" "/usr/local/bin/ssm-jump"
+RUN chown -R citools:citools . && bundle install && ln -s "/home/citools/ci-tools/brew-resources.rb" "/usr/local/bin/brew-resources" && ln -s "/home/citools/ci-tools//cycle-keys.rb" "/usr/local/bin/cycle-keys" && ln -s "/home/citools/ci-tools/deploy.rb" "/usr/local/bin/deploy" && ln -s "/home/citools/ci-tools/encrypt-logs.rb" "/usr/local/bin/encrypt-logs" && ln -s "/home/citools/ci-tools/generate-codeowners" "/usr/local/bin/generate-codeowners" && ln -s "/home/citools/ci-tools/linters" "/usr/local/bin/linters" && ln -s "/home/citools/ci-tools/ssh-jump" "/usr/local/bin/ssh-jump" && ln -s "/home/citools/ci-tools/ssm-jump" "/usr/local/bin/ssm-jump"
 
 # Entrypoint
 USER citools


### PR DESCRIPTION
# Summary

This is useful to be able to allow ubuntu user to access ci-tools scripts when container is started using `--user 1000` (to fix uid/gid ID mapping issues, like when accessing `.aws` or `.ssh` directories)

Also, now using `ADD` instead of `RUN git clone` to avoid build cache issues during git clone. When using the latter, if the repository is updated, changes might not be picked up (depending on local builder cache). When using `ADD`, the cached `HEAD` commit will be compared to the real one to automatically invalidate cache if needed.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
