### PR TITLE
Add --error flag to semgrep scan to fail on findings

### DIFF
--- a/linters
+++ b/linters
@@ -232,7 +232,7 @@ if [ -f .semgrepignore ]; then
     fi
   fi
 
-  semgrep scan --config=auto --severity=ERROR .
+  semgrep scan --config=auto --severity=ERROR --error .
 fi
 
 if [ -f .swiftlint.yml ]; then


### PR DESCRIPTION
# Summary

Add `--error` flag to semgrep scan command to ensure the linter exits with a non-zero status code when errors are found. This makes CI pipelines properly fail when semgrep detects security issues with ERROR severity.

## Types of changes

<!--
What types of changes does your code introduce? Put an `x` in the boxes that apply (no space around the brackets).
-->

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

<!--
Put an `x` in the boxes that apply (no space around the brackets). This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Single flag addition to existing command, behavior verified by semgrep's own exit code
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

## Further comments (if required)

<!--
Add comments here if breaking changes, complex database migration or reprocessing of existing data are required.

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
