### PR TITLE
Fix #350: Replace abandoned inifile gem with iniparse

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -251,17 +251,17 @@
     "requirements": "HTTP client for downloading gems from RubyGems API",
     "verification_reasoning": "Widely adopted Ruby HTTP client with active maintenance and security updates"
   },
-  "inifile": {
+  "iniparse": {
     "language": "Ruby",
-    "package": "inifile",
-    "version": "3.0.0",
-    "license": null,
-    "description": "Although made popular by Windows, INI files can be used on any system thanks",
-    "website": "http://rubygems.org/gems/inifile",
-    "last_verified_at": "2023-06-12",
+    "package": "iniparse",
+    "version": "1.5.0",
+    "license": "MIT",
+    "description": "A pure Ruby library for parsing INI documents.",
+    "website": "https://github.com/antw/iniparse",
+    "last_verified_at": "2026-02-24",
     "risk_level": "Medium",
     "requirements": "Parse AWS credentials INI files for key rotation",
-    "verification_reasoning": "Standard Ruby INI file parser used for reading and writing AWS credentials"
+    "verification_reasoning": "Actively maintained Ruby INI file parser used for reading and writing AWS credentials"
   },
   "jmespath": {
     "language": "Ruby",

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'aws-sdk-lambda', '>= 1.96.0'
 gem 'aws-sdk-ssm', '>= 1.150.0'
 gem 'base64', '>= 0.2.0'
 gem 'httparty', '>= 0.21.0'
-gem 'inifile', '>= 3.0.0'
+gem 'iniparse', '>= 1.5.0'
 gem 'nokogiri', '>= 1.15.2'
 gem 'optparse', '>= 0.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    inifile (3.0.0)
+    iniparse (1.5.0)
     jmespath (1.6.2)
     json (2.18.1)
     language_server-protocol (3.17.0.5)
@@ -158,7 +158,7 @@ DEPENDENCIES
   aws-sdk-ssm (>= 1.150.0)
   base64 (>= 0.2.0)
   httparty (>= 0.21.0)
-  inifile (>= 3.0.0)
+  iniparse (>= 1.5.0)
   nokogiri (>= 1.15.2)
   optparse (>= 0.3.1)
   rspec (>= 3.13.0)


### PR DESCRIPTION
## Summary

Replace the abandoned `inifile` gem (last released 2014, 11+ years inactive) with the actively maintained `iniparse` gem for parsing AWS credentials INI files in `cycle-keys.rb`. This addresses a security risk of using an unmaintained library in a credential-handling context and corrects the missing license in `.soup.json`.

**Key changes:**

- Replace `inifile` with `iniparse` in `Gemfile` and `Gemfile.lock`
- Update `cycle-keys.rb` to use `iniparse` API (`IniParse.open`, `credentials.save`, section iteration via `section.key`)
- Update `.soup.json` to reflect the new dependency with correct license (MIT), version (1.5.0), and website
- Update `spec/cycle_keys_spec.rb` to mock `IniParse::Document` instead of `IniFile` and align with new API (`save` instead of `write`)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified