### PR TITLE
Fix #351: Exit with code 1 for genuine CloudFormation ValidationErrors

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -212,7 +212,7 @@ def update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
     cfn.update_stack({ stack_name: stack_name, use_previous_template: true, parameters: parameters, capabilities: %w[CAPABILITY_IAM CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND], disable_rollback: false })
   rescue Aws::CloudFormation::Errors::ValidationError => e
     puts("Stopping here: #{e.message}")
-    exit
+    exit(e.message.include?('No updates are to be performed') ? 0 : 1)
   end
   wait_for_stack_update(cfn, stack_name)
   puts("Update completed successfully for cloudformation stack #{stack_name} with #{prefix}ImageId #{ami_id}.")


### PR DESCRIPTION
## Summary

The `ValidationError` rescue block in `deploy.rb` used a bare `exit` (exit code 0), causing all `ValidationError` exceptions to appear as successful outcomes. CloudFormation raises `ValidationError` for many reasons beyond "No updates are to be performed" (e.g., template validation failures, invalid parameters, insufficient capabilities). CI pipelines would incorrectly report success when a deployment failed due to a genuine error.

**Key changes:**

- Update `deploy.rb` to check the error message before deciding the exit code: exit 0 only for "No updates are to be performed", exit 1 for all other `ValidationError` messages
- Replace the single generic `ValidationError` test in `spec/deploy_spec.rb` with two specific tests: one verifying exit code 0 for the benign "no updates" case and one verifying exit code 1 for genuine validation errors

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified