### PR TITLE
Fix #353: Validate numeric input in ssm-jump instance selection

### DIFF
--- a/ssm-jump
+++ b/ssm-jump
@@ -118,7 +118,7 @@ else
 
   input=0
 
-  while [ ${input} -lt 1 ] || [ ${input} -gt "${max_lines}" ]; do
+  while ! [[ ${input} =~ ^[0-9]+$ ]] || [ ${input} -lt 1 ] || [ ${input} -gt "${max_lines}" ]; do
     echo -n "Connect to what line ? "
     read -r input
   done


### PR DESCRIPTION
## Summary

Non-numeric input (e.g., "abc") at the `ssm-jump` instance selection prompt caused confusing "integer expected" errors because the `while` loop condition used `[ ${input} -lt 1 ]` without first checking that the input was numeric. The shell test returned exit code 2 (treated as false), allowing the loop to exit with invalid input, which then caused multiple downstream errors.

**Key changes:**

- Add numeric validation `! [[ ${input} =~ ^[0-9]+$ ]]` to the while loop condition in `ssm-jump` so non-numeric input is rejected and the user is re-prompted cleanly

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Shell script with interactive prompt; validated by code review and manual testing
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified