### PR TITLE
Fix #354: Add Linux fallback for hadolint and golangci-lint install

### DIFF
--- a/linters
+++ b/linters
@@ -74,7 +74,12 @@ if [ -f .hadolint.yaml ]; then
   echo "Checking Dockerfiles..."
 
   if ! command -v hadolint &>/dev/null; then
-    brew install hadolint
+    if uname -s | grep Darwin &>/dev/null; then
+      brew install hadolint
+    else
+      wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
+      chmod +x /usr/local/bin/hadolint
+    fi
   fi
 
   # shellcheck disable=SC2046
@@ -85,7 +90,12 @@ if [ -f .golangci.yml ]; then
   echo "Checking Go..."
 
   if ! command -v golangci-lint &>/dev/null; then
-    brew install golangci-lint
+    if uname -s | grep Darwin &>/dev/null; then
+      brew install golangci-lint
+    else
+      go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      export PATH="${PATH}:${HOME}/go/bin"
+    fi
   fi
 
   golangci-lint run || FAILED=1
@@ -102,6 +112,8 @@ if [ -f .pmd.xml ]; then
   echo
 fi
 
+# .eslintrc.json is the legacy config format, which requires eslint@8.
+# eslint v9+ only supports the flat config format (eslint.config.js/mjs).
 if [ -f .eslintrc.json ]; then
   echo "Checking JS with eslint..."
 


### PR DESCRIPTION
## Summary

The `hadolint` and `golangci-lint` installation blocks in the `linters` script unconditionally called `brew install` without checking the OS, unlike all other linter blocks that use the `if uname -s | grep Darwin` pattern with Linux fallbacks. This caused `brew: command not found` failures on Ubuntu-based Docker containers, aborting all remaining linter checks.

**Key changes:**

- Add Darwin/Linux detection to the `hadolint` block in `linters`: uses `brew install` on macOS, downloads the binary directly from GitHub releases on Linux
- Add Darwin/Linux detection to the `golangci-lint` block in `linters`: uses `brew install` on macOS, uses `go install` on Linux (matching the pattern used by `actionlint` and `protolint`)

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Shell script install paths; validated by code review and matching existing patterns used by 10 other linter blocks
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified