### PR TITLE
Fix #355: Add credentials file existence check in cycle-keys.rb

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -110,6 +110,8 @@ if __FILE__ == $PROGRAM_NAME
     raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
 
     credentials_file_name = "#{Dir.home}/.aws/credentials"
+    raise("AWS credentials file not found: #{credentials_file_name}") unless File.exist?(credentials_file_name)
+
     puts("Reading #{credentials_file_name}")
     credentials = IniParse.open(credentials_file_name)
 


### PR DESCRIPTION
## Summary

When `~/.aws/credentials` does not exist, `cycle-keys.rb` would fail with a confusing low-level error instead of a clear, actionable message. This adds an explicit file existence check before attempting to open the credentials file.

**Key changes:**

- Add `File.exist?` check for the AWS credentials file in `cycle-keys.rb` before opening it, raising a clear error message `"AWS credentials file not found: <path>"` if the file is missing

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Guard clause in `__FILE__ == $PROGRAM_NAME` block which is excluded from test coverage; validated by code review
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified