### PR TITLE
Fix #357: Use default value for unbound positional arg in ssm-jump

### DIFF
--- a/ssm-jump
+++ b/ssm-jump
@@ -65,7 +65,7 @@ done
 set -- "${positional[@]}" # restore positional parameters
 
 # first positional argument is the target
-target="${1}"
+target="${1:-}"
 
 if [ -z "${profile}" ]; then
   fatal "No profile specified !"


### PR DESCRIPTION
## Summary

Under `set -u`, running `ssm-jump` with no positional arguments caused `${1}` to trigger a `bash: 1: unbound variable` error before the user-friendly `fatal "No target specified !"` message could execute. This changes `${1}` to `${1:-}` so the variable defaults to an empty string, allowing the existing `-z` check to display the intended error message.

**Key changes:**

- Change `target="${1}"` to `target="${1:-}"` in `ssm-jump` to prevent unbound variable error when no positional arguments are provided

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Shell script with interactive AWS SSM session; validated by code review and manual testing
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified