### PR TITLE
Fix #359: Add numeric validation for proxycommand port in ssm-jump

### DIFF
--- a/ssm-jump
+++ b/ssm-jump
@@ -135,6 +135,10 @@ else
 fi
 
 if [ -n "${proxycommand_port}" ]; then
+  if ! echo "${proxycommand_port}" | grep -qE '^[0-9]+$'; then
+    fatal "Port must be numeric: ${proxycommand_port}"
+  fi
+
   # for proxycommand, we *must* start an SSH session
   document="AWS-StartSSHSession"
 


### PR DESCRIPTION
## Summary

Add input validation for the `--proxy-command` port argument in `ssm-jump` to reject non-numeric values before passing them to the AWS SSM session.

**Key changes:**
- Add numeric validation (`grep -qE '^[0-9]+$'`) for `proxycommand_port` before it is used in the SSM start-session call
- Use the existing `fatal` helper to provide a clear error message when validation fails

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Bash script validation; covered by manual testing
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified