### PR TITLE
Fix #360: Fix broken quoting in ssm-jump proxycommand debug echo

### DIFF
--- a/ssm-jump
+++ b/ssm-jump
@@ -142,7 +142,7 @@ if [ -n "${proxycommand_port}" ]; then
   # for proxycommand, we *must* start an SSH session
   document="AWS-StartSSHSession"
 
-  echo "aws --profile "${profile}" ssm start-session --target "${instance_id}" --document-name "${document}" --parameters "portNumber=${proxycommand_port}""
+  echo "aws --profile \"${profile}\" ssm start-session --target \"${instance_id}\" --document-name \"${document}\" --parameters \"portNumber=${proxycommand_port}\""
   exec aws --profile "${profile}" ssm start-session --target "${instance_id}" --document-name "${document}" --parameters "portNumber=${proxycommand_port}"
 
 elif [ -z "${forward}" ]; then


### PR DESCRIPTION
## Summary

Fix broken double-quote nesting in the `ssm-jump` proxycommand debug echo statement. The inner double quotes were closing and reopening the outer quotes, producing garbled debug output. The actual `exec` command was correctly quoted.

**Key changes:**
- Escape inner double quotes in the proxycommand debug echo on line 145 of `ssm-jump`, matching the pattern already used in the other two echo statements (lines 149 and 172)

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Trivial quoting fix in a debug echo statement
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified