### PR TITLE
Fix #361: Pin jira-cli to known-good version instead of fetching latest

### DIFF
--- a/sync-jira-release
+++ b/sync-jira-release
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Pinned known-good version of jira-cli (update manually after verification)
+JIRA_CLI_VERSION="1.7.0"
+
 # Check if jira CLI is installed, if not install it
 if ! command -v jira &> /dev/null; then
   echo "jira CLI not found. Installing..."
@@ -21,15 +24,7 @@ if ! command -v jira &> /dev/null; then
     exit 1
   fi
 
-  # Get latest version
-  LATEST_VERSION=$(curl -s https://api.github.com/repos/ankitpokhrel/jira-cli/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/')
-
-  if [ -z "${LATEST_VERSION}" ]; then
-    echo "Error: Could not determine latest jira CLI version"
-    exit 1
-  fi
-
-  echo "Installing jira CLI version ${LATEST_VERSION} for ${OS}/${ARCH}..."
+  echo "Installing jira CLI version ${JIRA_CLI_VERSION} for ${OS}/${ARCH}..."
 
   # Map OS name for download URL
   if [ "${OS}" = "darwin" ]; then
@@ -41,9 +36,9 @@ if ! command -v jira &> /dev/null; then
   # Download and install
   TEMP_DIR=$(mktemp -d)
   trap 'rm -rf "${TEMP_DIR}"' exit
-  ARCHIVE_NAME="jira_${LATEST_VERSION}_${DOWNLOAD_OS}_${ARCH}.tar.gz"
-  DOWNLOAD_URL="https://github.com/ankitpokhrel/jira-cli/releases/download/v${LATEST_VERSION}/${ARCHIVE_NAME}"
-  CHECKSUMS_URL="https://github.com/ankitpokhrel/jira-cli/releases/download/v${LATEST_VERSION}/checksums.txt"
+  ARCHIVE_NAME="jira_${JIRA_CLI_VERSION}_${DOWNLOAD_OS}_${ARCH}.tar.gz"
+  DOWNLOAD_URL="https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/${ARCHIVE_NAME}"
+  CHECKSUMS_URL="https://github.com/ankitpokhrel/jira-cli/releases/download/v${JIRA_CLI_VERSION}/checksums.txt"
 
   curl -sL "${DOWNLOAD_URL}" -o "${TEMP_DIR}/jira.tar.gz"
   curl -sL "${CHECKSUMS_URL}" -o "${TEMP_DIR}/checksums.txt"
@@ -72,7 +67,7 @@ if ! command -v jira &> /dev/null; then
   tar -xzf "${TEMP_DIR}/jira.tar.gz" -C "${TEMP_DIR}"
 
   # Install to /usr/local/bin or ~/.local/bin
-  JIRA_BINARY="${TEMP_DIR}/jira_${LATEST_VERSION}_${DOWNLOAD_OS}_${ARCH}/bin/jira"
+  JIRA_BINARY="${TEMP_DIR}/jira_${JIRA_CLI_VERSION}_${DOWNLOAD_OS}_${ARCH}/bin/jira"
 
   if [ -w /usr/local/bin ]; then
     mv "${JIRA_BINARY}" /usr/local/bin/


### PR DESCRIPTION
## Summary

Replace dynamic version fetching of jira-cli from the GitHub API with a pinned known-good version to reduce supply chain risk. The existing SHA256 checksum verification is retained as an additional layer of protection.

**Key changes:**
- Add pinned `JIRA_CLI_VERSION="1.7.0"` constant at the top of `sync-jira-release`
- Remove the `curl` call to the GitHub API that dynamically fetched the latest release tag
- Rename all `LATEST_VERSION` references to `JIRA_CLI_VERSION`

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Bash script change; auto-installation path tested manually
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified