### PR TITLE
Fix #364: Fix typo in .soup.json verification_reasoning

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -537,7 +537,7 @@
     "last_verified_at": "2024-09-16",
     "risk_level": "Low",
     "requirements": "Ruby linter",
-    "verification_reasoning": "Most populat gem"
+    "verification_reasoning": "Most popular gem"
   },
   "rubocop-graphql": {
     "language": "Ruby",


### PR DESCRIPTION
## Summary

Fix a typo in the `rubocop-capybara` entry in `.soup.json`: "Most populat gem" to "Most popular gem".

**Key changes:**
- Fix typo in `verification_reasoning` for `rubocop-capybara` entry in `.soup.json`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Typo fix in documentation file
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified