### PR TITLE
Fix #365: Validate SSM document name pattern in ssm-jump

### DIFF
--- a/ssm-jump
+++ b/ssm-jump
@@ -75,6 +75,10 @@ if [ -z "${target}" ]; then
   fatal "No target specified !"
 fi
 
+if ! echo "${document}" | grep -qE '^[A-Za-z0-9_-]+$'; then
+  fatal "Invalid document name: ${document}"
+fi
+
 if [ ! -z "${forward}" ]; then
   IFS=":" read -a forward_array <<< "${forward}"
   if [ ${#forward_array[@]} -ne 3 ]; then


### PR DESCRIPTION
## Summary

Add input validation for the `--document` (`-d`) parameter in `ssm-jump` as a defense-in-depth measure. The document name is now validated against the pattern `^[A-Za-z0-9_-]+$`, rejecting names containing unexpected characters before they are passed to the AWS SSM session.

**Key changes:**
- Add regex validation for the `document` variable after existing input checks in `ssm-jump`
- Use the existing `fatal` helper for a clear error message on invalid input

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Bash script validation; covered by manual testing
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified