### PR TITLE
Fix #382: Add nil guard for subnet extraction in deploy.rb

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -242,6 +242,13 @@ def fetch_asg_mixed_parameters(environment, subnet)
   result
 end
 
+def extract_subnet_number(stack_name)
+  digits = stack_name.split('-').first.scan(/\d+/).first
+  raise("Unable to extract subnet number from stack name '#{stack_name}'") if digits.nil?
+
+  Integer(digits, 10)
+end
+
 def update_asg_capacity(asg_client, asg_name, base_capacity:, percent_above:, desired_capacity: nil, max_size: nil)
   params = {
     auto_scaling_group_name: asg_name,
@@ -337,7 +344,7 @@ if __FILE__ == $PROGRAM_NAME
 
     parameters = stacks_response.first.parameters
     environment = stack_name.split('-').first.tr('0-9', '')
-    subnet = Integer(stack_name.split('-').first.scan(/\d+/).first, 10)
+    subnet = extract_subnet_number(stack_name)
     prefix = parameter_prefix_for(options[:instance])
 
     update_ssm_parameters(parameters, prefix, ami_id, asg, options, environment, subnet)

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -181,6 +181,21 @@ RSpec.describe(Deploy) do
     end
   end
 
+  describe '#extract_subnet_number' do
+    it 'extracts subnet number from stack name' do
+      expect(extract_subnet_number('beta1-StackInstances-abc')).to(eq(1))
+    end
+
+    it 'extracts multi-digit subnet number' do
+      expect(extract_subnet_number('prod12-StackInstances-abc')).to(eq(12))
+    end
+
+    it 'raises error when no digits in first segment' do
+      expect { extract_subnet_number('beta-StackInstances-abc') }
+        .to(raise_error(RuntimeError, "Unable to extract subnet number from stack name 'beta-StackInstances-abc'"))
+    end
+  end
+
   describe '#find_standalone_instance' do
     let(:ec2) { Aws::EC2::Resource.new(stub_responses: true) }
     let(:options) { { instance: 'api', environment: 'beta' } }


### PR DESCRIPTION
## Summary

Add a nil guard before the `Integer()` call in `deploy.rb` to prevent an unhelpful `TypeError` when a CloudFormation stack name's first segment contains no digits (e.g., `beta-StackInstances-abc` instead of `beta1-StackInstances-abc`). The fix extracts the subnet parsing into a dedicated function with a descriptive error message.

**Key changes:**
- Extract `extract_subnet_number` function in `deploy.rb` with a nil guard that raises a descriptive error when no digits are found in the stack name's first segment
- Replace the inline `Integer()` call in the main deploy flow with a call to the new function
- Add 3 test cases in `spec/deploy_spec.rb` covering valid single-digit, multi-digit, and missing-digit scenarios

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified