### PR TITLE
Fix #383: Validate KMS keys exist before encrypting log groups

### DIFF
--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -33,6 +33,10 @@ def build_kms_key_map(kms)
     end
   end
 
+  %i[beta rc prod].each do |env|
+    raise("KMS key not found for environment '#{env}'") if keys[env].nil?
+  end
+
   keys
 end
 


### PR DESCRIPTION
## Summary

Add validation in `build_kms_key_map` to ensure all required KMS environment keys (beta, rc, prod) exist before proceeding with log group encryption. Previously, if a KMS key was missing from the AWS account, `nil` would be silently passed to `associate_kms_key`, causing an unhelpful AWS API error.

**Key changes:**
- Add validation loop in `encrypt-logs.rb` after building the KMS key map to check that all required environment keys exist, raising a descriptive error if any is missing
- Update existing tests in `spec/encrypt_logs_spec.rb` for "non-matching key description" and "no keys" contexts to expect the new validation error
- Add new "partially populated keys" test case to verify the error identifies the specific missing environment (prod)

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified