### PR TITLE
Fix #384: Remove stderr suppression from jira release list command

### DIFF
--- a/sync-jira-release
+++ b/sync-jira-release
@@ -113,7 +113,10 @@ fi
 
 # Verify the release exists in Jira and get its ID
 
-RELEASE_INFO=$(jira release list 2>/dev/null | tail -n +2 | awk -F'\t' -v name="${3}" '$2 == name {print $1}')
+RELEASE_INFO=$(jira release list 2>&1 | tail -n +2 | awk -F'\t' -v name="${3}" '$2 == name {print $1}') || {
+  echo "Error: Failed to list Jira releases. Check JIRA_API_TOKEN and JIRA_BASE_URL."
+  exit 1
+}
 
 if [ -z "${RELEASE_INFO}" ]; then
   echo "Error: Release '${3}' does not exist in Jira."


### PR DESCRIPTION
## Summary

Fix silent script failure when `jira release list` encounters an error (auth failure, network issue). The `2>/dev/null` suppressed all stderr output, causing the script to abort with exit code 1 and zero diagnostic output under `set -euo pipefail`.

**Key changes:**
- Replace `2>/dev/null` with `2>&1` in `sync-jira-release` so jira CLI errors are visible in the output
- Add `|| { ... }` error handler with a descriptive message pointing to `JIRA_API_TOKEN` and `JIRA_BASE_URL`

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Shell script with external jira CLI dependency; validated with shellcheck
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified