### PR TITLE
Fix #390: Fix inifile references to iniparse in architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,7 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 
 **Key Components:**
 
-- Credentials file parser using IniFile
+- Credentials file parser using IniParse
 - Key rotation logic with age-based thresholds
 
 **Functionality:**
@@ -125,7 +125,7 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 
 **Internal Dependencies:** None
 
-**External Dependencies:** aws-sdk-iam, inifile, optparse
+**External Dependencies:** aws-sdk-iam, iniparse, optparse
 
 ### encrypt-logs.rb
 


### PR DESCRIPTION
## Summary

Fix incorrect gem name references in `docs/architecture.md`. The documentation referenced the old `inifile`/`IniFile` gem, but the actual dependency (in `Gemfile`, `Gemfile.lock`, `.soup.json`, and `cycle-keys.rb`) is `iniparse`/`IniParse`.

**Key changes:**
- Replace "IniFile" with "IniParse" in the cycle-keys.rb key components description (line 116)
- Replace "inifile" with "iniparse" in the cycle-keys.rb external dependencies list (line 128)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only change correcting a gem name reference
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified