### PR TITLE
Fix #389: Add checksum verification for hadolint binary download

### DIFF
--- a/linters
+++ b/linters
@@ -78,6 +78,22 @@ if [ -f .hadolint.yaml ]; then
       brew install hadolint
     else
       wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
+      EXPECTED_CHECKSUM=$(wget -qO - https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64.sha256 | awk '{print $1}')
+
+      if command -v sha256sum &> /dev/null; then
+        ACTUAL_CHECKSUM=$(sha256sum /usr/local/bin/hadolint | awk '{print $1}')
+      else
+        ACTUAL_CHECKSUM=$(shasum -a 256 /usr/local/bin/hadolint | awk '{print $1}')
+      fi
+
+      if [ "${EXPECTED_CHECKSUM}" != "${ACTUAL_CHECKSUM}" ]; then
+        echo "Error: Checksum verification failed for hadolint!"
+        echo "Expected: ${EXPECTED_CHECKSUM}"
+        echo "Actual:   ${ACTUAL_CHECKSUM}"
+        rm -f /usr/local/bin/hadolint
+        exit 1
+      fi
+
       chmod +x /usr/local/bin/hadolint
     fi
   fi


### PR DESCRIPTION
## Summary

Add SHA256 checksum verification for the hadolint binary downloaded on Linux in the `linters` script. Previously, the binary was downloaded and executed without any integrity check. The fix downloads the `.sha256` sidecar file from the same GitHub release and verifies the binary against it, following the same pattern used in `sync-jira-release` for jira CLI downloads.

**Key changes:**
- Download the `.sha256` checksum file from the hadolint GitHub release in `linters`
- Verify the downloaded binary checksum using `sha256sum` (Linux) or `shasum -a 256` (fallback)
- On checksum mismatch, print expected vs actual values, remove the binary, and exit with error

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Shell script with external binary download; validated with shellcheck
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified