### PR TITLE
Fix #388: Add JIRA_USER_EMAIL to env var validation in sync-jira-release

### DIFF
--- a/sync-jira-release
+++ b/sync-jira-release
@@ -106,7 +106,7 @@ if [ "$#" -ne 3 ]; then
   exit 1
 fi
 
-if [ -z "${JIRA_API_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${JIRA_BASE_URL}" ]; then
+if [ -z "${JIRA_USER_EMAIL}" ] || [ -z "${JIRA_API_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${JIRA_BASE_URL}" ]; then
   echo "Error: Required environment variables \`JIRA_USER_EMAIL\`, \`JIRA_API_TOKEN\`, \`JIRA_BASE_URL\`, and \`GITHUB_TOKEN\` must be set."
   exit 1
 fi

--- a/tests/sync_jira_release.bats
+++ b/tests/sync_jira_release.bats
@@ -2,6 +2,7 @@
 
 setup() {
   export PATH="${BATS_TEST_DIRNAME}/../:${PATH}"
+  export JIRA_USER_EMAIL="test@example.com"
   export JIRA_API_TOKEN="test-token"
   export GITHUB_TOKEN="test-token"
   export JIRA_BASE_URL="https://test.atlassian.net"
@@ -26,6 +27,18 @@ setup() {
   run sync-jira-release
   [ "$status" -eq 1 ]
   [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exits with error when JIRA_USER_EMAIL is empty" {
+  export JIRA_USER_EMAIL=""
+
+  function jira() { :; }
+  function gh() { :; }
+  export -f jira gh
+
+  run sync-jira-release tag1 tag2 release1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Required environment variables"* ]]
 }
 
 @test "exits with error when JIRA_API_TOKEN is empty" {


### PR DESCRIPTION
## Summary

Fix validation inconsistency where `JIRA_USER_EMAIL` was listed in the error message as a required environment variable but was not actually checked in the validation condition. The jira CLI requires this variable for API token authentication.

**Key changes:**
- Add `JIRA_USER_EMAIL` check to the environment variable validation condition in `sync-jira-release`
- Add `JIRA_USER_EMAIL` to the test setup in `tests/sync_jira_release.bats`
- Add bats test for empty `JIRA_USER_EMAIL` validation in `tests/sync_jira_release.bats`

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified