### PR TITLE
Fix #391: Reduce parameter count in SSM parameter functions

### DIFF
--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe(Deploy) do
         parameter = instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'APIImageId', parameter_value: nil, use_previous_value: nil)
         allow(parameter).to(receive(:parameter_value=))
         allow(parameter).to(receive(:use_previous_value=))
-        update_ssm_parameters([parameter], 'API', 'ami-12345678', { min_size: 1, max_size: 4, desired_capacity: 2 }, { type: 't3.micro' }, 'beta', 1)
+        update_ssm_parameters([parameter], 'API', 'ami-12345678', { min_size: 1, max_size: 4, desired_capacity: 2 }, { type: 't3.micro' }, '/beta/1')
         expect(ssm).to(have_received(:put_parameter).with(hash_including(value: 'ami-12345678')))
       end
     end
@@ -417,7 +417,7 @@ RSpec.describe(Deploy) do
         parameter = instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'DbPassword')
         allow(parameter).to(receive(:parameter_value=))
         allow(parameter).to(receive(:use_previous_value=))
-        update_ssm_parameters([parameter], 'API', 'ami-12345678', { min_size: 1, max_size: 4, desired_capacity: 2 }, { type: 't3.micro' }, 'beta', 1)
+        update_ssm_parameters([parameter], 'API', 'ami-12345678', { min_size: 1, max_size: 4, desired_capacity: 2 }, { type: 't3.micro' }, '/beta/1')
         expect(parameter).to(have_received(:parameter_value=).with(nil))
       end
     end
@@ -583,7 +583,7 @@ RSpec.describe(Deploy) do
 
       it 'returns a hash of parameter names to values' do
         parameter = instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'APIImageId')
-        result = capture_ssm_snapshot([parameter], 'API', 'ami-new', asg, options, 'beta', 1)
+        result = capture_ssm_snapshot([parameter], 'API', 'ami-new', asg, options, '/beta/1')
         expect(result).to(eq(param_name => 'ami-old'))
       end
     end
@@ -591,7 +591,7 @@ RSpec.describe(Deploy) do
     context 'when no parameters need updating' do
       it 'returns empty hash' do
         parameter = instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'Unknown')
-        expect(capture_ssm_snapshot([parameter], 'API', 'ami-new', asg, options, 'beta', 1)).to(eq({}))
+        expect(capture_ssm_snapshot([parameter], 'API', 'ami-new', asg, options, '/beta/1')).to(eq({}))
       end
     end
   end


### PR DESCRIPTION
## Summary

Reduce parameter count in `update_ssm_parameters` and `capture_ssm_snapshot` from 7 to 6 by pre-computing the SSM path prefix at the call site. The `environment` and `subnet` parameters were always used together solely for SSM path construction.

**Key changes:**
- Replace `environment` and `subnet` parameters with a single `ssm_prefix` parameter in `update_ssm_parameters` in `deploy.rb`
- Apply the same refactoring to `capture_ssm_snapshot` in `deploy.rb`
- Pre-compute `ssm_prefix = "/#{environment}/#{subnet}"` at the call site in `deploy.rb`
- Update all test calls in `spec/deploy_spec.rb` to pass `'/beta/1'` instead of `'beta', 1`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified