### PR TITLE
Add missing external dependencies to architecture documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 
 **Internal Dependencies:** None
 
-**External Dependencies:** aws-sdk-iam, iniparse, optparse
+**External Dependencies:** aws-sdk-iam, date, iniparse, optparse
 
 ### encrypt-logs.rb
 
@@ -263,7 +263,7 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 
 **Internal Dependencies:** None
 
-**External Dependencies:** bundler, httparty
+**External Dependencies:** bundler, digest, httparty
 
 ## Software of Unknown Provenance
 


### PR DESCRIPTION
## Summary

Update the architecture documentation to include missing external Ruby library dependencies for two software units.

**Key changes:**
- Add `date` to the external dependencies list for `create-iam-user.rb` (line 130)
- Add `digest` to the external dependencies list for the bundler/httparty dependent unit (line 266)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?: Documentation-only change, no functional code modified
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
