### PR TITLE
Update CODEOWNERS to team ownership and auto-merge to use bot PAT

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,14 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*                        @ydesgagn
+*                        @Cloud-Officer/Maintainers
 
 # build/deploy related files
 
-.github/                 @ydesgagn
-.gitignore               @ydesgagn
-.hadolint.yaml           @ydesgagn
-.markdownlint-cli2.yaml  @ydesgagn
-.rubocop.yml             @ydesgagn
-.ruby-version            @ydesgagn
-.yamllint.yml            @ydesgagn
-Dockerfile               @ydesgagn
+.github/                 @Cloud-Officer/Maintainers
+.gitignore               @Cloud-Officer/Maintainers
+.hadolint.yaml           @Cloud-Officer/Maintainers
+.markdownlint-cli2.yaml  @Cloud-Officer/Maintainers
+.rubocop.yml             @Cloud-Officer/Maintainers
+.ruby-version            @Cloud-Officer/Maintainers
+.yamllint.yml            @Cloud-Officer/Maintainers
+Dockerfile               @Cloud-Officer/Maintainers

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -75,5 +75,5 @@ jobs:
       if: steps.check.outputs.is_owner == 'true'
       run: gh pr review --approve "$PR"
       env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
         PR: "${{github.event.pull_request.number}}"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -13,6 +13,7 @@ globs:
   - "!**/dist/**"
   - "!**/build/**"
   - "!**/target/**"
+  - "!docs/code-review.md"
 config:
   default: true
   first-line-heading: false


### PR DESCRIPTION
## Summary

Switch repository ownership from an individual contributor to the Cloud-Officer Maintainers team, update the auto-merge workflow to use a personal access token so approvals can be performed by the bot identity, and exclude the generated code-review document from markdownlint.

**Key changes:**

- Replace `@ydesgagn` with `@Cloud-Officer/Maintainers` for all CODEOWNERS rules (global and build/deploy paths)
- Switch the auto-merge approval step in `.github/workflows/auto-merge.yml` from `secrets.GITHUB_TOKEN` to `secrets.GH_BOT_PAT` so the approval is made under the bot account rather than the default Actions token
- Add `docs/code-review.md` to the markdownlint ignore globs in `.markdownlint-cli2.yaml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Configuration-only changes (CODEOWNERS, workflow secret, lint ignore) with no executable behavior to cover with unit tests.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified