### PR TITLE
Fix bash arg/env validation under set -u and HTTPS repo URL parsing

### DIFF
--- a/generate-codeowners
+++ b/generate-codeowners
@@ -6,12 +6,12 @@ IGNORED_EXCLUDES="${GHB_IGNORED_EXCLUDES:-$(github-build --get_ignored_folders |
 
 function check_file()
 {
-  if [ -z "${1}" ]; then
+  if [ -z "${1:-}" ]; then
     echo "ERROR: extension cannot be empty!"
     return 1
   fi
 
-  if [ -z "${2}" ]; then
+  if [ -z "${2:-}" ]; then
     echo "ERROR: default owners cannot be empty!"
     exit 1
   fi
@@ -22,12 +22,12 @@ function check_file()
   fi
 }
 
-if [ -z "${1}" ]; then
+if [ -z "${1:-}" ]; then
   echo "ERROR: build files owners cannot be empty!"
   exit 1
 fi
 
-if [ -z "${2}" ]; then
+if [ -z "${2:-}" ]; then
   echo "ERROR: default owners cannot be empty!"
   exit 1
 fi

--- a/sync-jira-release
+++ b/sync-jira-release
@@ -108,7 +108,7 @@ if [ "$#" -ne 3 ]; then
   exit 1
 fi
 
-if [ -z "${JIRA_USER_EMAIL}" ] || [ -z "${JIRA_API_TOKEN}" ] || [ -z "${GITHUB_TOKEN}" ] || [ -z "${JIRA_BASE_URL}" ]; then
+if [ -z "${JIRA_USER_EMAIL:-}" ] || [ -z "${JIRA_API_TOKEN:-}" ] || [ -z "${GITHUB_TOKEN:-}" ] || [ -z "${JIRA_BASE_URL:-}" ]; then
   echo "Error: Required environment variables \`JIRA_USER_EMAIL\`, \`JIRA_API_TOKEN\`, \`JIRA_BASE_URL\`, and \`GITHUB_TOKEN\` must be set."
   exit 1
 fi
@@ -162,7 +162,7 @@ fi
 
 echo "Using Jira project prefix: ${JIRA_PREFIX}"
 
-repo=$(git config --get remote.origin.url | cut -d : -f 2 | sed 's/\.git$//')
+repo=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
 temp_file=$(mktemp)
 trap 'rm -f "${temp_file}" "${temp_file}_unique"' exit
 


### PR DESCRIPTION
## Summary

These scripts run with `set -euo pipefail`, but several `[ -z "${VAR}" ]` guards used the bare variable form, which trips `set -u` and aborts the script with `unbound variable` before the documented error message can print. This PR replaces those guards with default-expansion `${VAR:-}` so the friendly messages actually fire. Also replaces the SSH-only `git config --get remote.origin.url | cut -d : -f 2 | …` repo-URL parse in `sync-jira-release` with `gh repo view --json nameWithOwner`, which handles both SSH and HTTPS remotes.

**Key changes:**

- `generate-codeowners`: use `${1:-}` / `${2:-}` in the four arg-presence checks (lines 9, 14, 25, 30) so `ERROR: build files owners cannot be empty!` and the related messages can actually print.
- `sync-jira-release`: use `${JIRA_USER_EMAIL:-}`, `${JIRA_API_TOKEN:-}`, `${GITHUB_TOKEN:-}`, `${JIRA_BASE_URL:-}` (line 111) so the env-var-missing error message is reachable.
- `sync-jira-release`: replace SSH-only URL parser at line 165 with `gh repo view --json nameWithOwner -q '.nameWithOwner'` so HTTPS-cloned repos also work end-to-end.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: The existing BATS tests in tests/sync_jira_release.bats and tests/generate_codeowners.bats already cover the missing-arg and missing-env-var paths and continue to pass; they exercise exactly the branches this PR repairs.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified