### PR TITLE
Extract testable rollback methods from deploy.rb and cycle-keys.rb

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -52,6 +52,32 @@ def create_and_save_new_key(iam, credentials, profile, user_name, credentials_fi
   new_access_key_id
 end
 
+def rollback_key_change(iam, credentials, profile, user_name, credentials_file_name, new_access_key_id, original_access_key, original_secret_key, error_context)
+  puts("\tRolling back due to: #{error_context}")
+  begin
+    puts("\tDeleting newly created key #{new_access_key_id}...")
+    iam.delete_access_key(
+      {
+        access_key_id: new_access_key_id,
+        user_name: user_name
+      }
+    )
+    puts("\tRollback: deleted new key")
+
+    credentials[profile]['aws_access_key_id'] = original_access_key
+    credentials[profile]['aws_secret_access_key'] = original_secret_key
+    File.open("#{credentials_file_name}.lock", File::RDWR | File::CREAT, 0o600) do |lock_file|
+      lock_file.flock(File::LOCK_EX)
+      credentials.save
+      puts("\tRollback: restored original credentials")
+    end
+  rescue StandardError => e
+    puts("\tWARNING: Rollback failed - manual cleanup required!")
+    puts("\tNew key #{new_access_key_id} may still be active")
+    pp(e)
+  end
+end
+
 def disable_and_delete_old_key(iam, access_key, user_name, rollback)
   puts("\tDisabling old access key")
   begin
@@ -170,33 +196,9 @@ if __FILE__ == $PROGRAM_NAME
 
       new_access_key_id = create_and_save_new_key(iam, credentials, profile, user_name, credentials_file_name)
 
-      # Helper to rollback: delete new key and restore old credentials
       rollback =
         lambda do |error_context|
-          puts("\tRolling back due to: #{error_context}")
-          begin
-            puts("\tDeleting newly created key #{new_access_key_id}...")
-            iam.delete_access_key(
-              {
-                access_key_id: new_access_key_id,
-                user_name: user_name
-              }
-            )
-            puts("\tRollback: deleted new key")
-
-            # Restore original credentials
-            credentials[profile]['aws_access_key_id'] = access_key
-            credentials[profile]['aws_secret_access_key'] = secret_key
-            File.open("#{credentials_file_name}.lock", File::RDWR | File::CREAT, 0o600) do |lock_file|
-              lock_file.flock(File::LOCK_EX)
-              credentials.save
-              puts("\tRollback: restored original credentials")
-            end
-          rescue StandardError => e
-            puts("\tWARNING: Rollback failed - manual cleanup required!")
-            puts("\tNew key #{new_access_key_id} may still be active")
-            pp(e)
-          end
+          rollback_key_change(iam, credentials, profile, user_name, credentials_file_name, new_access_key_id, access_key, secret_key, error_context)
         end
 
       disable_and_delete_old_key(iam, access_key, user_name, rollback)

--- a/deploy.rb
+++ b/deploy.rb
@@ -255,6 +255,21 @@ def update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
   puts("Update completed successfully for cloudformation stack #{stack_name} with #{prefix}ImageId #{ami_id}.")
 end
 
+def update_stack_with_ssm_rollback(cfn, stack_name, parameters, prefix, ami_id, ssm_snapshot)
+  update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
+rescue SystemExit => e
+  if e.status.nonzero?
+    puts('CloudFormation update failed, rolling back SSM parameters...')
+    restore_ssm_parameters(ssm_snapshot)
+  end
+
+  raise
+rescue StandardError
+  puts('CloudFormation update failed, rolling back SSM parameters...')
+  restore_ssm_parameters(ssm_snapshot)
+  raise
+end
+
 def fetch_asg_mixed_parameters(environment, subnet)
   ssm = Aws::SSM::Client.new
   response = ssm.get_parameters({ names: ["/#{environment}/#{subnet}/OnDemandPercentAbove", "/#{environment}/#{subnet}/OnDemandBaseCapacity"], with_decryption: true })
@@ -381,20 +396,7 @@ if __FILE__ == $PROGRAM_NAME
     ssm_snapshot = capture_ssm_snapshot(parameters, prefix, ami_id, asg, options, ssm_prefix)
     update_ssm_parameters(parameters, prefix, ami_id, asg, options, ssm_prefix)
 
-    begin
-      update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
-    rescue SystemExit => e
-      if e.status.nonzero?
-        puts('CloudFormation update failed, rolling back SSM parameters...')
-        restore_ssm_parameters(ssm_snapshot)
-      end
-
-      raise
-    rescue StandardError
-      puts('CloudFormation update failed, rolling back SSM parameters...')
-      restore_ssm_parameters(ssm_snapshot)
-      raise
-    end
+    update_stack_with_ssm_rollback(cfn, stack_name, parameters, prefix, ami_id, ssm_snapshot)
 
     mixed_params = fetch_asg_mixed_parameters(environment, subnet)
     new_capacity = (asg[:desired_capacity] * asg_multiplier) + asg_increase

--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -105,6 +105,50 @@ RSpec.describe(CycleKeys) do
     end
   end
 
+  describe '#rollback_key_change' do
+    let(:iam)         { Aws::IAM::Client.new(stub_responses: true) }
+    let(:credentials) { instance_double(IniParse::Document)        }
+    let(:cred_hash)   { {}                                         }
+    let(:lock_file)   { instance_double(File)                      }
+
+    def call_rollback
+      rollback_key_change(iam, credentials, 'test-profile', 'testuser', '/tmp/test-credentials', 'AKIANEWKEY123', 'AKIAOLDKEY123', 'oldsecret123', 'failed to disable old key')
+    end
+
+    before do
+      allow(iam).to(receive(:delete_access_key).and_call_original)
+      allow(credentials).to(receive(:[]).with('test-profile').and_return(cred_hash))
+      allow(credentials).to(receive(:save))
+      allow(File).to(receive(:open).with('/tmp/test-credentials.lock', anything, anything).and_yield(lock_file))
+      allow(lock_file).to(receive(:flock))
+    end
+
+    it 'deletes the new key and saves restored credentials under lock', :aggregate_failures do
+      call_rollback
+      expect(iam).to(have_received(:delete_access_key).with(hash_including(access_key_id: 'AKIANEWKEY123', user_name: 'testuser')))
+      expect(lock_file).to(have_received(:flock).with(File::LOCK_EX))
+      expect(credentials).to(have_received(:save))
+    end
+
+    it 'restores the original access-key fields in the credentials hash', :aggregate_failures do
+      call_rollback
+      expect(cred_hash['aws_access_key_id']).to(eq('AKIAOLDKEY123'))
+      expect(cred_hash['aws_secret_access_key']).to(eq('oldsecret123'))
+    end
+
+    it 'swallows errors from delete_access_key without raising' do
+      allow(iam).to(receive(:delete_access_key).and_raise(Aws::IAM::Errors::ServiceError.new(nil, 'API error')))
+      expect { call_rollback }
+        .not_to(raise_error)
+    end
+
+    it 'swallows errors from credentials.save without raising' do
+      allow(credentials).to(receive(:save).and_raise(Errno::EACCES.new('permission denied')))
+      expect { call_rollback }
+        .not_to(raise_error)
+    end
+  end
+
   describe '#disable_and_delete_old_key' do
     let(:iam) { Aws::IAM::Client.new(stub_responses: true) }
     let(:access_key) { 'AKIAOLDKEY123'       }

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -582,6 +582,71 @@ RSpec.describe(Deploy) do
     end
   end
 
+  describe '#update_stack_with_ssm_rollback' do
+    let(:cfn)          { Aws::CloudFormation::Client.new(stub_responses: true) }
+    let(:ssm)          { Aws::SSM::Client.new(stub_responses: true)            }
+    let(:param_name)   { '/beta/1/APIImageId'                                  }
+    let(:ssm_snapshot) { { param_name => 'ami-old' }                           }
+
+    before do
+      allow(Aws::SSM::Client).to(receive(:new).and_return(ssm))
+      allow(ssm).to(receive(:put_parameter).and_call_original)
+    end
+
+    context 'when CloudFormation update succeeds' do
+      before do
+        allow(cfn).to(receive(:update_stack).and_call_original)
+        allow(self).to(receive(:sleep))
+        cfn.stub_responses(:describe_stacks, { stacks: [{ stack_name: 'test-stack', stack_status: 'UPDATE_COMPLETE', creation_time: Time.now }] })
+      end
+
+      it 'does not restore SSM parameters' do
+        update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', ssm_snapshot)
+        expect(ssm).not_to(have_received(:put_parameter))
+      end
+    end
+
+    context 'when CloudFormation update fails with a generic error' do
+      before { allow(cfn).to(receive(:update_stack).and_raise(StandardError.new('boom'))) }
+
+      it 'restores SSM parameters and re-raises', :aggregate_failures do
+        expect { update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', ssm_snapshot) }
+          .to(raise_error(StandardError, 'boom'))
+        expect(ssm).to(have_received(:put_parameter).with(hash_including(name: param_name, value: 'ami-old')))
+      end
+    end
+
+    context 'when CloudFormation returns "No updates are to be performed" (SystemExit 0)' do
+      before { allow(cfn).to(receive(:update_stack).and_raise(Aws::CloudFormation::Errors::ValidationError.new(nil, 'No updates are to be performed'))) }
+
+      it 'does NOT restore SSM parameters (success path)', :aggregate_failures do
+        expect { update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', ssm_snapshot) }
+          .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+        expect(ssm).not_to(have_received(:put_parameter))
+      end
+    end
+
+    context 'when CloudFormation returns a genuine ValidationError (SystemExit 1)' do
+      before { allow(cfn).to(receive(:update_stack).and_raise(Aws::CloudFormation::Errors::ValidationError.new(nil, 'Template validation failed'))) }
+
+      it 'restores SSM parameters and re-raises SystemExit(1)', :aggregate_failures do
+        expect { update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', ssm_snapshot) }
+          .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+        expect(ssm).to(have_received(:put_parameter).with(hash_including(name: param_name, value: 'ami-old')))
+      end
+    end
+
+    context 'with empty snapshot' do
+      before { allow(cfn).to(receive(:update_stack).and_raise(StandardError.new('boom'))) }
+
+      it 'still re-raises but does not call put_parameter', :aggregate_failures do
+        expect { update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', {}) }
+          .to(raise_error(StandardError, 'boom'))
+        expect(ssm).not_to(have_received(:put_parameter))
+      end
+    end
+  end
+
   describe '#capture_ssm_snapshot' do
     let(:ssm)        { Aws::SSM::Client.new(stub_responses: true)        }
     let(:asg)        { { min_size: 1, max_size: 4, desired_capacity: 2 } }


### PR DESCRIPTION
## Summary

Two pieces of failure-recovery logic that previously lived inside `:nocov:` orchestrator blocks (and therefore couldn't be unit-tested) are now extracted into top-level helper methods with full RSpec coverage. The orchestrator sites are reduced to thin call-throughs — no behavior change.

**Key changes:**

- `cycle-keys.rb`: extract the in-line `lambda do |error_context|` rollback (delete the new IAM key, restore the original `~/.aws/credentials` entries under `flock`) into a new `rollback_key_change(...)` method outside the `:nocov:` block. The orchestrator's lambda now just delegates.
- `deploy.rb`: extract the `begin/rescue SystemExit/rescue StandardError` SSM-restoration dispatch around `update_cloudformation_stack` into a new `update_stack_with_ssm_rollback(...)` method outside the `:nocov:` block. The orchestrator is now a single-line call.
- `spec/cycle_keys_spec.rb`: add 4 RSpec examples for `rollback_key_change` covering the happy path, credentials-hash restoration, and graceful swallowing of failures from `iam.delete_access_key` and `credentials.save`.
- `spec/deploy_spec.rb`: add 5 RSpec examples for `update_stack_with_ssm_rollback` covering success (no restore), generic StandardError (restore + re-raise), `SystemExit(0)` "no updates" (no restore), `SystemExit(1)` validation failure (restore + re-raise), and empty-snapshot edge case.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified