### PR TITLE
Refactor deploy/cycle-keys/linters for testability and reduced duplication

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -78,6 +78,66 @@ def rollback_key_change(iam, credentials, profile, user_name, credentials_file_n
   end
 end
 
+KEY_AGE_DAYS_THRESHOLD = 80 # AWS rotates at 90; this provides a 10-day buffer for cron schedules.
+
+def build_iam_client(region, access_key, secret_key)
+  Aws::IAM::Client.new(
+    region: region,
+    credentials: Aws::Credentials.new(access_key, secret_key)
+  )
+end
+
+def find_primary_key_user(metadata_list, primary_key_id)
+  metadata = metadata_list.find { |key_metadata| key_metadata.access_key_id == primary_key_id }
+  return [nil, 0] if metadata.nil?
+
+  age_days = Integer(Time.now - metadata.create_date) / (24 * 60 * 60)
+  [metadata.user_name, age_days]
+end
+
+def process_credential_profile(credentials, profile, options)
+  region = credentials[profile]['region'] || 'us-east-1'
+  access_key = credentials[profile]['aws_access_key_id']
+  secret_key = credentials[profile]['aws_secret_access_key']
+  credentials_file_name = "#{Dir.home}/.aws/credentials"
+
+  puts("Processing \"#{profile}\" in #{region}: #{access_key}")
+  iam = build_iam_client(region, access_key, secret_key)
+
+  begin
+    response = iam.list_access_keys
+  rescue StandardError => e
+    puts("\tError listing access keys")
+    pp(e)
+    return :error
+  end
+
+  return :no_keys if response.access_key_metadata.none?
+
+  user_name, age_days = find_primary_key_user(response.access_key_metadata, access_key)
+  cleanup_secondary_keys(iam, access_key, response.access_key_metadata)
+
+  if user_name != options[:username]
+    puts("\tUsername does not match: #{user_name}")
+    return :username_mismatch
+  end
+
+  if age_days < KEY_AGE_DAYS_THRESHOLD && options[:force].nil?
+    puts("\tSkipping, key is only #{age_days} day(s) old")
+    return :too_young
+  end
+
+  new_access_key_id = create_and_save_new_key(iam, credentials, profile, user_name, credentials_file_name)
+
+  rollback =
+    lambda do |error_context|
+      rollback_key_change(iam, credentials, profile, user_name, credentials_file_name, new_access_key_id, access_key, secret_key, error_context)
+    end
+
+  disable_and_delete_old_key(iam, access_key, user_name, rollback)
+  :rotated
+end
+
 def disable_and_delete_old_key(iam, access_key, user_name, rollback)
   puts("\tDisabling old access key")
   begin
@@ -111,101 +171,55 @@ def disable_and_delete_old_key(iam, access_key, user_name, rollback)
   end
 end
 
+def parse_cycle_keys_options(argv = ARGV)
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: cycle-keys.rb options'
+    opts.separator('')
+    opts.separator('options')
+
+    opts.on('--profile profile', String)
+    opts.on('--username username', String)
+    opts.on('--force')
+    opts.on('-h', '--help') do
+      puts(opts)
+      exit(1)
+    end
+  end.parse!(argv, into: options)
+
+  mandatory = %i[profile username]
+  missing = mandatory.select { |param| options[param].nil? }
+  raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
+
+  options
+end
+
+def run_cycle_keys(options)
+  credentials_file_name = "#{Dir.home}/.aws/credentials"
+  raise("AWS credentials file not found: #{credentials_file_name}") unless File.exist?(credentials_file_name)
+
+  puts("Reading #{credentials_file_name}")
+  credentials = IniParse.open(credentials_file_name)
+
+  credentials.each do |section|
+    next if section.key != options[:profile]
+
+    result = process_credential_profile(credentials, section.key, options)
+    case result
+    when :error, :username_mismatch then exit(1)
+    when :too_young then exit(0)
+    end
+  end
+end
+
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
   begin
-    options = {}
-
-    OptionParser.new do |opts|
-      opts.banner = 'Usage: cycle-keys.rb options'
-      opts.separator('')
-      opts.separator('options')
-
-      opts.on('--profile profile', String)
-      opts.on('--username username', String)
-      opts.on('--force')
-      opts.on('-h', '--help') do
-        puts(opts)
-        exit(1)
-      end
-    end.parse!(into: options)
-
-    mandatory = %i[profile username]
-    missing = mandatory.select { |param| options[param].nil? }
-
-    raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
-
-    credentials_file_name = "#{Dir.home}/.aws/credentials"
-    raise("AWS credentials file not found: #{credentials_file_name}") unless File.exist?(credentials_file_name)
-
-    puts("Reading #{credentials_file_name}")
-    credentials = IniParse.open(credentials_file_name)
-
-    credentials.each do |section|
-      profile = section.key
-      next if profile != options[:profile]
-
-      region = credentials[profile]['region'] || 'us-east-1'
-      access_key = credentials[profile]['aws_access_key_id']
-      secret_key = credentials[profile]['aws_secret_access_key']
-
-      puts("Processing \"#{profile}\" in #{region}: #{access_key}")
-      iam = Aws::IAM::Client.new(
-        region: region,
-        credentials: Aws::Credentials.new(access_key, secret_key)
-      )
-
-      # list current keys
-
-      user_name = ''
-      age = 0
-      begin
-        response = iam.list_access_keys
-      rescue StandardError => e
-        puts("\tError listing access keys")
-        pp(e)
-        exit(1)
-      end
-
-      next if response.access_key_metadata.none?
-
-      response.access_key_metadata.each do |key_metadata|
-        if key_metadata.access_key_id == access_key
-          age = (Integer(Time.now - key_metadata.create_date) / (24 * 60 * 60))
-          user_name = key_metadata.user_name
-        end
-      end
-
-      cleanup_secondary_keys(iam, access_key, response.access_key_metadata)
-
-      # check username
-
-      if user_name != options[:username]
-        puts("\tUsername does not match: #{user_name}")
-        exit(1)
-      end
-
-      # check date
-
-      if age < 80 and options[:force].nil?
-        puts("\tSkipping, key is only #{age} day(s) old")
-        exit(0)
-      end
-
-      # create new key
-
-      new_access_key_id = create_and_save_new_key(iam, credentials, profile, user_name, credentials_file_name)
-
-      rollback =
-        lambda do |error_context|
-          rollback_key_change(iam, credentials, profile, user_name, credentials_file_name, new_access_key_id, access_key, secret_key, error_context)
-        end
-
-      disable_and_delete_old_key(iam, access_key, user_name, rollback)
-    end
+    run_cycle_keys(parse_cycle_keys_options)
   rescue StandardError => e
-    puts(e)
-    puts(e.backtrace)
+    warn(e)
+    warn(e.backtrace)
     exit(1)
   end
 end

--- a/deploy.rb
+++ b/deploy.rb
@@ -30,33 +30,35 @@ def load_balanced_instance?(instance)
   LOAD_BALANCED_INSTANCES.include?(instance)
 end
 
-def wait_for_healthy_instances(elb, target_group_arn)
-  puts('Waiting for all instances to be healthy...')
+def poll_until(description:, max_attempts: MAX_POLL_ATTEMPTS, interval: POLL_INTERVAL)
   attempts = 0
   loop do
-    raise('Timed out waiting for healthy instances') if (attempts += 1) > MAX_POLL_ATTEMPTS
+    raise("Timed out #{description}") if (attempts += 1) > max_attempts
 
-    sleep(POLL_INTERVAL)
+    sleep(interval)
+    break if yield
+  end
+end
+
+def wait_for_healthy_instances(elb, target_group_arn)
+  puts('Waiting for all instances to be healthy...')
+  poll_until(description: 'waiting for healthy instances') do
     unhealthy =
       elb.describe_target_health({ target_group_arn: target_group_arn })
          .target_health_descriptions.count { |h| h.target_health.state != 'healthy' }
     puts("Waiting on #{unhealthy} unhealthy targets...")
-    break if unhealthy.zero?
+    unhealthy.zero?
   end
 end
 
 def wait_for_asg_instance_count(asg_client, asg_name, target_count)
-  attempts = 0
-  loop do
-    raise("Timed out waiting for ASG #{asg_name} to reach #{target_count} instances") if (attempts += 1) > MAX_POLL_ATTEMPTS
-
-    sleep(POLL_INTERVAL)
+  poll_until(description: "waiting for ASG #{asg_name} to reach #{target_count} instances") do
     response = asg_client.describe_auto_scaling_groups({ auto_scaling_group_names: [asg_name] }).auto_scaling_groups
     raise("Unable to describe ASG #{asg_name}") if response.empty?
 
     count = response.first.instances.count
     puts("Waiting on instances #{count}/#{target_count}...")
-    break if count == target_count
+    count == target_count
   end
 end
 
@@ -184,18 +186,22 @@ def resolve_parameter_value(key, prefix, ami_id, asg, options)
   end
 end
 
+CFN_SECRET_PARAMETERS = %w[DbPassword MqPassword SendGridApiKey].freeze
+
 def update_ssm_parameters(parameters, prefix, ami_id, asg, options, ssm_prefix)
-  ignored_parameters = %w[DbPassword MqPassword SendGridApiKey]
   ssm = Aws::SSM::Client.new
   parameters.each do |parameter|
     replace_with = resolve_parameter_value(parameter.parameter_key, prefix, ami_id, asg, options)
+    next if replace_with.nil?
 
-    unless replace_with.nil?
-      puts("Updating SSM parameter '#{ssm_prefix}/#{parameter.parameter_key}' with value = '#{replace_with}'...")
-      ssm.put_parameter({ name: "#{ssm_prefix}/#{parameter.parameter_key}", value: replace_with, type: 'String', overwrite: true })
-    end
+    puts("Updating SSM parameter '#{ssm_prefix}/#{parameter.parameter_key}' with value = '#{replace_with}'...")
+    ssm.put_parameter({ name: "#{ssm_prefix}/#{parameter.parameter_key}", value: replace_with, type: 'String', overwrite: true })
+  end
+end
 
-    next unless ignored_parameters.include?(parameter.parameter_key)
+def mark_cfn_secrets_for_previous_value!(parameters)
+  parameters.each do |parameter|
+    next unless CFN_SECRET_PARAMETERS.include?(parameter.parameter_key)
 
     parameter.parameter_value = nil
     parameter.use_previous_value = true
@@ -230,16 +236,13 @@ end
 
 def wait_for_stack_update(cfn, stack_name)
   failure_states = %w[UPDATE_FAILED UPDATE_ROLLBACK_COMPLETE UPDATE_ROLLBACK_FAILED ROLLBACK_COMPLETE ROLLBACK_FAILED]
-  attempts = 0
-  loop do
-    raise("Timed out waiting for stack #{stack_name} to update") if (attempts += 1) > MAX_POLL_ATTEMPTS
-
-    sleep(POLL_INTERVAL)
+  poll_until(description: "waiting for stack #{stack_name} to update") do
     response = cfn.describe_stacks({ stack_name: stack_name }).stacks
     raise("Unable to describe stack #{stack_name}") if response.empty?
 
-    break if response.first.stack_status == 'UPDATE_COMPLETE'
     raise('Stack update failed') if failure_states.include?(response.first.stack_status)
+
+    response.first.stack_status == 'UPDATE_COMPLETE'
   end
 end
 
@@ -309,140 +312,180 @@ def update_asg_capacity(asg_client, asg_name, base_capacity:, percent_above:, de
   asg_client.update_auto_scaling_group(params)
 end
 
+def resolve_capacity_factors(options)
+  asg_increase = options[:environment].start_with?('prod') ? 3 : 1
+  asg_multiplier = 2
+
+  if options[:preserve_desired_capacity]
+    asg_increase = 0
+    asg_multiplier = 1
+  end
+
+  { asg_increase: asg_increase, asg_multiplier: asg_multiplier }
+end
+
+def compute_asg_capacity_plan(asg, asg_increase:, asg_multiplier:)
+  new_capacity = (asg[:desired_capacity] * asg_multiplier) + asg_increase
+  new_max = asg[:max_size] < new_capacity ? (asg[:max_size] * asg_multiplier) + asg_increase : nil
+  { new_capacity: new_capacity, new_max: new_max }
+end
+
+def resolve_ami_id(options)
+  return options[:ami] if options[:ami]
+
+  ec2 = Aws::EC2::Resource.new
+  instance_id, instance_name = find_standalone_instance(ec2, options)
+  create_ami(ec2, instance_id, instance_name, options)
+end
+
+def discover_cfn_stack_context(cfn, options)
+  stack_name = find_cloudformation_stack(cfn, options)
+  stacks_response = cfn.describe_stacks({ stack_name: stack_name }).stacks
+  raise("Unable to describe stack #{stack_name}") if stacks_response.empty?
+
+  environment = stack_name.split('-').first.tr('0-9', '')
+  subnet = extract_subnet_number(stack_name)
+  {
+    stack_name: stack_name,
+    parameters: stacks_response.first.parameters,
+    environment: environment,
+    subnet: subnet,
+    prefix: parameter_prefix_for(options[:instance]),
+    ssm_prefix: "/#{environment}/#{subnet}"
+  }
+end
+
+def warm_up_after_scale_up(elb, target_group_arn, options)
+  if load_balanced_instance?(options[:instance])
+    sleep(WARMUP_SHORT) if options[:instance] == 'grpc'
+    wait_for_healthy_instances(elb, target_group_arn)
+  end
+
+  puts('Waiting for cache/instances to warm up...')
+  sleep(options[:instance] == 'grpc' ? WARMUP_LONG : WARMUP_SHORT)
+end
+
+def scale_down_after_deploy(asg_resources, asg, mixed_params, new_capacity, elb, target_group_arn, options)
+  if options[:skip_scale_down]
+    puts("Setting max_size to #{asg[:max_size]}...")
+    update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above], max_size: asg[:max_size])
+    return
+  end
+
+  puts("Setting desired capacity from #{new_capacity} to #{asg[:desired_capacity]}...")
+  update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above], desired_capacity: asg[:desired_capacity], max_size: asg[:max_size])
+
+  if load_balanced_instance?(options[:instance])
+    sleep(POLL_INTERVAL)
+    wait_for_healthy_instances(elb, target_group_arn)
+  end
+
+  puts('Waiting for auto scaling group to stop the instances...')
+  wait_for_asg_instance_count(asg_resources.client, asg[:name], asg[:desired_capacity])
+end
+
+def run_rolling_deploy(asg_resources, asg, mixed_params, new_capacity, elb, target_group_arn, options)
+  if new_capacity > asg[:desired_capacity]
+    puts('Waiting for auto scaling group to start the instances...')
+    wait_for_asg_instance_count(asg_resources.client, asg[:name], new_capacity)
+    warm_up_after_scale_up(elb, target_group_arn, options)
+  end
+
+  scale_down_after_deploy(asg_resources, asg, mixed_params, new_capacity, elb, target_group_arn, options)
+ensure
+  puts('Restoring ASG mixed-instances policy...')
+  update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above])
+end
+
+def discover_load_balancer(options)
+  return [nil, nil] unless load_balanced_instance?(options[:instance])
+
+  elb = Aws::ElasticLoadBalancingV2::Client.new
+  [elb, find_target_group(elb, options)]
+end
+
+def run_deployment(options)
+  if options[:profile]
+    puts("Setting profile '#{options[:profile]}'...")
+    Aws.config.update({ profile: options[:profile] })
+  end
+
+  if options[:lambda_publish_version]
+    publish_lambda_and_update_cloudfront(options)
+    return
+  end
+
+  ami_id = resolve_ami_id(options)
+  if options[:create_ami_only] && options[:ami].nil?
+    puts('Exiting now as --create_ami_only was supplied.')
+    return
+  end
+
+  factors = resolve_capacity_factors(options)
+  asg_resources = Aws::AutoScaling::Resource.new
+  asg = find_auto_scaling_group(asg_resources, options)
+  elb, target_group_arn = discover_load_balancer(options)
+
+  cfn = Aws::CloudFormation::Client.new
+  ctx = discover_cfn_stack_context(cfn, options)
+
+  ssm_snapshot = capture_ssm_snapshot(ctx[:parameters], ctx[:prefix], ami_id, asg, options, ctx[:ssm_prefix])
+  update_ssm_parameters(ctx[:parameters], ctx[:prefix], ami_id, asg, options, ctx[:ssm_prefix])
+  mark_cfn_secrets_for_previous_value!(ctx[:parameters])
+
+  update_stack_with_ssm_rollback(cfn, ctx[:stack_name], ctx[:parameters], ctx[:prefix], ami_id, ssm_snapshot)
+
+  mixed_params = fetch_asg_mixed_parameters(ctx[:environment], ctx[:subnet])
+  plan = compute_asg_capacity_plan(asg, **factors)
+
+  puts("Increasing desired capacity from #{asg[:desired_capacity]} to #{plan[:new_capacity]}...")
+  update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: 100, desired_capacity: plan[:new_capacity], max_size: plan[:new_max])
+
+  run_rolling_deploy(asg_resources, asg, mixed_params, plan[:new_capacity], elb, target_group_arn, options)
+
+  puts("Update completed successfully for Auto scaling group #{asg[:name]}.")
+  puts('Deployment completed successfully.')
+end
+
+def parse_deploy_options(argv = ARGV)
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.banner = 'Usage: deploy.rb options'
+    opts.separator('')
+    opts.separator('options')
+    opts.on('--ami ami', String)
+    opts.on('--create_ami_only')
+    opts.on('--environment environment', String)
+    opts.on('--instance instance', String)
+    opts.on('--type instance_type', String)
+    opts.on('--lambda_publish_version function_name', String)
+    opts.on('--profile profile', String)
+    opts.on('--preserve_desired_capacity')
+    opts.on('--skip_scale_down')
+    opts.on('--spot_target_capacity spot_target_capacity', Integer)
+    opts.on('-h', '--help') do
+      puts(opts)
+      exit(0)
+    end
+  end.parse!(argv, into: options)
+
+  mandatory = %i[environment instance profile]
+  missing = mandatory.select { |param| options[param].nil? }
+  raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
+
+  options
+end
+
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
   begin
-    options = {}
-    asg_increase = 1
-    asg_multiplier = 2
-
-    OptionParser.new do |opts|
-      opts.banner = 'Usage: deploy.rb options'
-      opts.separator('')
-      opts.separator('options')
-      opts.on('--ami ami', String)
-      opts.on('--create_ami_only')
-      opts.on('--environment environment', String)
-      opts.on('--instance instance', String)
-      opts.on('--type instance_type', String)
-      opts.on('--lambda_publish_version function_name', String)
-      opts.on('--profile profile', String)
-      opts.on('--preserve_desired_capacity')
-      opts.on('--skip_scale_down')
-      opts.on('--spot_target_capacity spot_target_capacity', Integer)
-      opts.on('-h', '--help') do
-        puts(opts)
-        exit(0)
-      end
-    end.parse!(into: options)
-
-    mandatory = %i[environment instance profile]
-    missing = mandatory.select { |param| options[param].nil? }
-    raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
-
+    options = parse_deploy_options
     puts('Starting deployment...')
-
-    if options[:profile]
-      puts("Setting profile '#{options[:profile]}'...")
-      Aws.config.update({ profile: options[:profile] })
-    end
-
-    if options[:lambda_publish_version]
-      publish_lambda_and_update_cloudfront(options)
-      exit
-    end
-
-    asg_increase = 3 if options[:environment].start_with?('prod')
-
-    if options[:preserve_desired_capacity]
-      asg_increase = 0
-      asg_multiplier = 1
-    end
-
-    if options[:ami]
-      ami_id = options[:ami]
-    else
-      ec2 = Aws::EC2::Resource.new
-      instance_id, instance_name = find_standalone_instance(ec2, options)
-      ami_id = create_ami(ec2, instance_id, instance_name, options)
-
-      if options[:create_ami_only]
-        puts('Exiting now as --create_ami_only was supplied.')
-        exit
-      end
-    end
-
-    asg_resources = Aws::AutoScaling::Resource.new
-    asg = find_auto_scaling_group(asg_resources, options)
-    elb = target_group_arn = nil
-
-    if load_balanced_instance?(options[:instance])
-      elb = Aws::ElasticLoadBalancingV2::Client.new
-      target_group_arn = find_target_group(elb, options)
-    end
-
-    cfn = Aws::CloudFormation::Client.new
-    stack_name = find_cloudformation_stack(cfn, options)
-
-    stacks_response = cfn.describe_stacks({ stack_name: stack_name }).stacks
-    raise("Unable to describe stack #{stack_name}") if stacks_response.empty?
-
-    parameters = stacks_response.first.parameters
-    environment = stack_name.split('-').first.tr('0-9', '')
-    subnet = extract_subnet_number(stack_name)
-    prefix = parameter_prefix_for(options[:instance])
-
-    ssm_prefix = "/#{environment}/#{subnet}"
-    ssm_snapshot = capture_ssm_snapshot(parameters, prefix, ami_id, asg, options, ssm_prefix)
-    update_ssm_parameters(parameters, prefix, ami_id, asg, options, ssm_prefix)
-
-    update_stack_with_ssm_rollback(cfn, stack_name, parameters, prefix, ami_id, ssm_snapshot)
-
-    mixed_params = fetch_asg_mixed_parameters(environment, subnet)
-    new_capacity = (asg[:desired_capacity] * asg_multiplier) + asg_increase
-
-    puts("Increasing desired capacity from #{asg[:desired_capacity]} to #{new_capacity}...")
-    new_max = asg[:max_size] < new_capacity ? (asg[:max_size] * asg_multiplier) + asg_increase : nil
-    update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: 100, desired_capacity: new_capacity, max_size: new_max)
-
-    begin
-      if new_capacity > asg[:desired_capacity]
-        puts('Waiting for auto scaling group to start the instances...')
-        wait_for_asg_instance_count(asg_resources.client, asg[:name], new_capacity)
-
-        if load_balanced_instance?(options[:instance])
-          sleep(WARMUP_SHORT) if options[:instance] == 'grpc'
-          wait_for_healthy_instances(elb, target_group_arn)
-        end
-
-        puts('Waiting for cache/instances to warm up...')
-        sleep(options[:instance] == 'grpc' ? WARMUP_LONG : WARMUP_SHORT)
-      end
-
-      if options[:skip_scale_down]
-        puts("Setting max_size to #{asg[:max_size]}...")
-        update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above], max_size: asg[:max_size])
-      else
-        puts("Setting desired capacity from #{new_capacity} to #{asg[:desired_capacity]}...")
-        update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above], desired_capacity: asg[:desired_capacity], max_size: asg[:max_size])
-        if load_balanced_instance?(options[:instance])
-          sleep(POLL_INTERVAL)
-          wait_for_healthy_instances(elb, target_group_arn)
-        end
-
-        puts('Waiting for auto scaling group to stop the instances...')
-        wait_for_asg_instance_count(asg_resources.client, asg[:name], asg[:desired_capacity])
-      end
-    ensure
-      puts('Restoring ASG mixed-instances policy...')
-      update_asg_capacity(asg_resources.client, asg[:name], base_capacity: mixed_params[:base_capacity], percent_above: mixed_params[:percent_above])
-    end
-
-    puts("Update completed successfully for Auto scaling group #{asg[:name]}.")
-    puts('Deployment completed successfully.')
+    run_deployment(options)
   rescue StandardError => e
-    puts(e)
-    puts(e.backtrace)
+    warn(e)
+    warn(e.backtrace)
     exit(1)
   end
 end

--- a/linters
+++ b/linters
@@ -4,6 +4,38 @@ shopt -s globstar
 
 FAILED=0
 
+# Returns 0 (success) on macOS so callers can use `if is_darwin; then brew ... else <other> ; fi`.
+is_darwin() {
+  [ "$(uname -s)" = "Darwin" ]
+}
+
+# Emits "sudo" or "" depending on whether the named command's path is user-writable.
+# Usage: ${SUDO_FOR_NPM} npm install -g foo
+sudo_for_user_command() {
+  if command -v "${1}" | grep "${HOME}" &>/dev/null; then
+    echo ""
+  else
+    echo "sudo"
+  fi
+}
+
+# Common find filter used for files-to-lint discovery. Pass the -name pattern as $1.
+find_lintable() {
+  find . -name "${1}" \
+    -not -path "*/vendor/*" \
+    -not -path "*/node_modules/*" \
+    -not -path "*/Libraries/*" \
+    -not -path "*/Pods/*" \
+    -not -path "*/.build/*" \
+    -not -path "*/Carthage/*" \
+    -not -path "*/DerivedData/*" \
+    -not -path "*/venv/*" \
+    -not -path "*/.venv/*" \
+    -not -path "*/dist/*" \
+    -not -path "*/build/*" \
+    -not -path "*/target/*"
+}
+
 yml_files=(.github/workflows/*.yml)
 yaml_files=(.github/workflows/*.yaml)
 
@@ -11,7 +43,7 @@ if [[ -e ${yml_files[0]} ]] || [[ -e ${yaml_files[0]} ]]; then
   echo "Checking GitHub Actions workflow files..."
 
   if ! command -v actionlint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install actionlint
     else
       go install github.com/rhysd/actionlint/cmd/actionlint@latest
@@ -26,16 +58,10 @@ if [ -f .markdownlint-cli2.yaml ]; then
   echo "Checking Markdown..."
 
   if ! command -v markdownlint-cli2 &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install markdownlint-cli2
     elif command -v npm &>/dev/null; then
-      if command -v npm | grep "${HOME}" &>/dev/null; then
-        SUDO=""
-      else
-        SUDO="sudo"
-      fi
-
-      ${SUDO} npm install -g markdownlint-cli2
+      $(sudo_for_user_command npm) npm install -g markdownlint-cli2
     fi
   fi
 
@@ -46,7 +72,7 @@ if [ -f .yamllint.yml ]; then
   echo "Checking YAML..."
 
   if ! command -v yamllint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install yamllint
     else
       sudo apt-get --yes install --no-install-recommends yamllint
@@ -60,7 +86,7 @@ if [ -f .shellcheckrc ]; then
   echo "Checking shell scripts..."
 
   if ! command -v shellcheck &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install shellcheck
     else
       sudo apt-get --yes install --no-install-recommends shellcheck
@@ -68,14 +94,14 @@ if [ -f .shellcheckrc ]; then
   fi
 
   # shellcheck disable=SC2046
-  shellcheck --external-sources $(find . -name "*.sh" -not -path "*/vendor/*" -not -path "*/node_modules/*" -not -path "*/Libraries/*" -not -path "*/Pods/*" -not -path "*/.build/*" -not -path "*/Carthage/*" -not -path "*/DerivedData/*" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/dist/*" -not -path "*/build/*" -not -path "*/target/*") || FAILED=1
+  shellcheck --external-sources $(find_lintable "*.sh") || FAILED=1
 fi
 
 if [ -f .hadolint.yaml ]; then
   echo "Checking Dockerfiles..."
 
   if ! command -v hadolint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install hadolint
     else
       wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
@@ -100,14 +126,14 @@ if [ -f .hadolint.yaml ]; then
   fi
 
   # shellcheck disable=SC2046
-  hadolint $(find . -name Dockerfile -not -path "*/vendor/*" -not -path "*/node_modules/*" -not -path "*/Libraries/*" -not -path "*/Pods/*" -not -path "*/.build/*" -not -path "*/Carthage/*" -not -path "*/DerivedData/*" -not -path "*/venv/*" -not -path "*/.venv/*" -not -path "*/dist/*" -not -path "*/build/*" -not -path "*/target/*") || FAILED=1
+  hadolint $(find_lintable "Dockerfile") || FAILED=1
 fi
 
 if [ -f .cfnlintrc ]; then
   echo "Checking CloudFormation templates..."
 
   if ! command -v cfn-lint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install cfn-lint
     else
       pip3 install cfn-lint
@@ -121,7 +147,7 @@ if [ -f .golangci.yml ]; then
   echo "Checking Go..."
 
   if ! command -v golangci-lint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install golangci-lint
     else
       go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
@@ -161,20 +187,14 @@ if [ -f .eslintrc.json ]; then
   fi
 
   if [ ${INSTALL_ESLINT} -eq 1 ]; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       npm install -g eslint@8
     else
       if ! command -v npm &>/dev/null; then
         sudo apt-get --yes install --no-install-recommends npm
       fi
 
-      if command -v npm | grep "${HOME}" &>/dev/null; then
-        SUDO=""
-      else
-        SUDO="sudo"
-      fi
-
-      ${SUDO} npm install -g eslint@8
+      $(sudo_for_user_command npm) npm install -g eslint@8
     fi
   fi
 
@@ -185,7 +205,7 @@ if [ -f .editorconfig ]; then
   echo "Checking Kotlin with ktlint..."
 
   if ! command -v ktlint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install ktlint
     else
       sudo apt-get --yes install --no-install-recommends ktlint
@@ -199,7 +219,7 @@ if [ -f .bandit ]; then
   echo "Checking Python with bandit..."
 
   if ! command -v bandit &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install bandit
     else
       sudo apt-get --yes install --no-install-recommends python3-bandit
@@ -214,16 +234,12 @@ if [ -f .flake8 ]; then
   echo "Checking Python with flake8..."
 
   if ! command -v flake8 &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install flake8
     else
       sudo apt-get --yes install --no-install-recommends flake8
     fi
   fi
-
-  #if ! pip3 list | grep flake8-docstrings &>/dev/null; then
-  #  pip3 install --upgrade flake8-docstrings
-  #fi
 
   flake8 . || FAILED=1
 fi
@@ -232,7 +248,7 @@ if [ -f .protolint.yaml ]; then
   echo "Checking Protocol Buffer with protolint..."
 
   if ! command -v protolint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew tap yoheimuta/protolint
       brew install protolint
     else
@@ -248,16 +264,10 @@ if [ -f .rubocop.yml ]; then
   echo "Checking Ruby..."
 
   if ! rubocop --version &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       gem install rubocop rubocop-capybara rubocop-graphql rubocop-i18n rubocop-minitest rubocop-performance rubocop-rails rubocop-rake rubocop-rspec rubocop-rspec_rails rubocop-thread_safety
     else
-      if command -v gem | grep "${HOME}" &>/dev/null; then
-        SUDO=""
-      else
-        SUDO="sudo"
-      fi
-
-      ${SUDO} gem install rubocop rubocop-capybara rubocop-graphql rubocop-i18n rubocop-minitest rubocop-performance rubocop-rails rubocop-rake rubocop-rspec rubocop-rspec_rails rubocop-thread_safety
+      $(sudo_for_user_command gem) gem install rubocop rubocop-capybara rubocop-graphql rubocop-i18n rubocop-minitest rubocop-performance rubocop-rails rubocop-rake rubocop-rspec rubocop-rspec_rails rubocop-thread_safety
     fi
   fi
 
@@ -269,7 +279,7 @@ if [ -f .semgrepignore ]; then
   echo "Checking with semgrep..."
 
   if ! command -v semgrep &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install semgrep
     else
       pip3 install semgrep
@@ -283,7 +293,7 @@ if [ -f .trivyignore ]; then
   echo "Checking with trivy..."
 
   if ! command -v trivy &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install trivy
     else
       curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
@@ -325,7 +335,7 @@ if [ -f .swiftlint.yml ]; then
   echo "Checking Swift..."
 
   if ! command -v swiftlint &>/dev/null; then
-    if uname -s | grep Darwin &>/dev/null; then
+    if is_darwin; then
       brew install swiftlint
     else
       echo "Error: only supported on MacOS!"

--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -149,6 +149,84 @@ RSpec.describe(CycleKeys) do
     end
   end
 
+  describe '#find_primary_key_user' do
+    let(:now)      { Time.now }
+    let(:created)  { now - (45 * 24 * 60 * 60)                                                                                                   }
+    let(:other)    { instance_double(Aws::IAM::Types::AccessKeyMetadata, access_key_id: 'AKIAOTHER', user_name: 'other', create_date: created)   }
+    let(:matching) { instance_double(Aws::IAM::Types::AccessKeyMetadata, access_key_id: 'AKIAMATCH', user_name: 'matched', create_date: created) }
+
+    before { stub_const('Time', class_double(Time, now: now).as_stubbed_const) }
+
+    it 'returns [user_name, age_days] for the matching access key' do
+      expect(find_primary_key_user([other, matching], 'AKIAMATCH')).to(eq(['matched', 45]))
+    end
+
+    it 'returns [nil, 0] when no key matches' do
+      expect(find_primary_key_user([], 'AKIAMISSING')).to(eq([nil, 0]))
+    end
+  end
+
+  describe '#parse_cycle_keys_options' do
+    it 'parses required args', :aggregate_failures do
+      options = parse_cycle_keys_options(%w[--profile dev --username alice])
+      expect(options[:profile]).to(eq('dev'))
+      expect(options[:username]).to(eq('alice'))
+    end
+
+    it 'raises when missing args' do
+      expect { parse_cycle_keys_options(%w[--profile dev]) }
+        .to(raise_error(OptionParser::MissingArgument, /username/))
+    end
+  end
+
+  describe '#process_credential_profile' do
+    let(:iam)         { Aws::IAM::Client.new(stub_responses: true) }
+    let(:credentials) { instance_double(IniParse::Document)                                                           }
+    let(:cred_hash)   { %w[region aws_access_key_id aws_secret_access_key].zip(%w[us-east-1 AKIACURRENT secret]).to_h }
+    let(:options)     { { profile: 'dev', username: 'alice' }                                                         }
+
+    before do
+      allow(Aws::IAM::Client).to(receive(:new).and_return(iam))
+      allow(credentials).to(receive(:[]).with('dev').and_return(cred_hash))
+    end
+
+    context 'when list_access_keys raises' do
+      before { iam.stub_responses(:list_access_keys, 'ServiceError') }
+
+      it 'returns :error and does not propagate' do
+        expect(process_credential_profile(credentials, 'dev', options)).to(eq(:error))
+      end
+    end
+
+    context 'when no keys exist' do
+      before { iam.stub_responses(:list_access_keys, { access_key_metadata: [] }) }
+
+      it 'returns :no_keys' do
+        expect(process_credential_profile(credentials, 'dev', options)).to(eq(:no_keys))
+      end
+    end
+
+    context 'when the primary key user does not match' do
+      before do
+        iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'other', create_date: Time.now - (200 * 24 * 60 * 60), status: 'Active' }] })
+      end
+
+      it 'returns :username_mismatch' do
+        expect(process_credential_profile(credentials, 'dev', options)).to(eq(:username_mismatch))
+      end
+    end
+
+    context 'when the key is too young and --force is not set' do
+      before do
+        iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'alice', create_date: Time.now - (10 * 24 * 60 * 60), status: 'Active' }] })
+      end
+
+      it 'returns :too_young' do
+        expect(process_credential_profile(credentials, 'dev', options)).to(eq(:too_young))
+      end
+    end
+  end
+
   describe '#disable_and_delete_old_key' do
     let(:iam) { Aws::IAM::Client.new(stub_responses: true) }
     let(:access_key) { 'AKIAOLDKEY123'       }

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -412,14 +412,28 @@ RSpec.describe(Deploy) do
       end
     end
 
-    context 'when parameter is in ignored list' do
-      it 'marks ignored parameters with use_previous_value', :aggregate_failures do
+    context 'when parameter is a known CFN secret' do
+      it 'does not call put_parameter on the secret' do
         parameter = instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'DbPassword')
-        allow(parameter).to(receive(:parameter_value=))
-        allow(parameter).to(receive(:use_previous_value=))
         update_ssm_parameters([parameter], 'API', 'ami-12345678', { min_size: 1, max_size: 4, desired_capacity: 2 }, { type: 't3.micro' }, '/beta/1')
-        expect(parameter).to(have_received(:parameter_value=).with(nil))
+        expect(ssm).not_to(have_received(:put_parameter))
       end
+    end
+  end
+
+  describe '#mark_cfn_secrets_for_previous_value!' do
+    let(:secret)     { instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'DbPassword') }
+    let(:non_secret) { instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'APIImageId') }
+
+    before do
+      allow(secret).to(receive(:parameter_value=))
+      allow(secret).to(receive(:use_previous_value=))
+      mark_cfn_secrets_for_previous_value!([secret, non_secret])
+    end
+
+    it 'marks each known secret for previous-value reuse', :aggregate_failures do
+      expect(secret).to(have_received(:parameter_value=).with(nil))
+      expect(secret).to(have_received(:use_previous_value=).with(true))
     end
   end
 
@@ -578,6 +592,246 @@ RSpec.describe(Deploy) do
       it 'exits with code 1', :aggregate_failures do
         expect { update_cloudformation_stack(cfn, 'test-stack', [], 'API', 'ami-123') }
           .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+      end
+    end
+  end
+
+  describe '#resolve_capacity_factors' do
+    it 'returns asg_increase=1, asg_multiplier=2 for beta', :aggregate_failures do
+      result = resolve_capacity_factors({ environment: 'beta' })
+      expect(result[:asg_increase]).to(eq(1))
+      expect(result[:asg_multiplier]).to(eq(2))
+    end
+
+    it 'returns asg_increase=3 for prod environments' do
+      expect(resolve_capacity_factors({ environment: 'prod1' })[:asg_increase]).to(eq(3))
+    end
+
+    it 'overrides to asg_increase=0, asg_multiplier=1 when preserve_desired_capacity', :aggregate_failures do
+      result = resolve_capacity_factors({ environment: 'prod1', preserve_desired_capacity: true })
+      expect(result[:asg_increase]).to(eq(0))
+      expect(result[:asg_multiplier]).to(eq(1))
+    end
+  end
+
+  describe '#compute_asg_capacity_plan' do
+    it 'computes new_capacity = (desired * multiplier) + increase' do
+      asg = { desired_capacity: 4, max_size: 10 }
+      expect(compute_asg_capacity_plan(asg, asg_increase: 1, asg_multiplier: 2)[:new_capacity]).to(eq(9))
+    end
+
+    it 'returns new_max=nil when max_size already exceeds new_capacity' do
+      asg = { desired_capacity: 2, max_size: 20 }
+      expect(compute_asg_capacity_plan(asg, asg_increase: 1, asg_multiplier: 2)[:new_max]).to(be_nil)
+    end
+
+    it 'returns scaled new_max when current max_size is below new_capacity' do
+      asg = { desired_capacity: 4, max_size: 4 }
+      expect(compute_asg_capacity_plan(asg, asg_increase: 1, asg_multiplier: 2)[:new_max]).to(eq(9))
+    end
+  end
+
+  describe '#resolve_ami_id' do
+    context 'when --ami is supplied' do
+      before { allow(Aws::EC2::Resource).to(receive(:new)) }
+
+      it 'returns it directly' do
+        expect(resolve_ami_id({ ami: 'ami-supplied' })).to(eq('ami-supplied'))
+      end
+
+      it 'does not call Aws::EC2::Resource.new' do
+        resolve_ami_id({ ami: 'ami-supplied' })
+        expect(Aws::EC2::Resource).not_to(have_received(:new))
+      end
+    end
+
+    context 'when --ami is not supplied' do
+      let(:ec2) { Aws::EC2::Resource.new(stub_responses: true) }
+
+      before do
+        allow(Aws::EC2::Resource).to(receive(:new).and_return(ec2))
+        ec2.client.stub_responses(:describe_instances, build_instance_response('i-abc', 'api-beta1-standalone'))
+        ec2.client.stub_responses(:create_image, { image_id: 'ami-new' })
+        allow(Aws::EC2::Waiters::ImageAvailable).to(receive(:new).and_return(instance_double(Aws::EC2::Waiters::ImageAvailable, wait: nil)))
+      end
+
+      it 'discovers standalone and creates an AMI' do
+        expect(resolve_ami_id({ instance: 'api', environment: 'beta1' })).to(eq('ami-new'))
+      end
+    end
+  end
+
+  describe '#discover_cfn_stack_context' do
+    let(:cfn) { Aws::CloudFormation::Client.new(stub_responses: true) }
+
+    before do
+      cfn.stub_responses(:list_stacks, { stack_summaries: [{ stack_name: 'beta1-StackInstances-x', stack_status: 'UPDATE_COMPLETE', creation_time: Time.now }] })
+      cfn.stub_responses(:describe_stacks, { stacks: [{ stack_name: 'beta1-StackInstances-x', stack_status: 'UPDATE_COMPLETE', creation_time: Time.now, parameters: [{ parameter_key: 'APIImageId', parameter_value: 'ami-old' }] }] })
+    end
+
+    it 'returns environment, subnet, prefix and ssm_prefix derived from the stack name' do
+      ctx = discover_cfn_stack_context(cfn, { instance: 'api', environment: 'beta1' })
+      expect(ctx).to(include(environment: 'beta', subnet: 1, prefix: 'API', ssm_prefix: '/beta/1'))
+    end
+
+    it 'returns the stack parameters' do
+      ctx = discover_cfn_stack_context(cfn, { instance: 'api', environment: 'beta1' })
+      expect(ctx[:parameters].first.parameter_key).to(eq('APIImageId'))
+    end
+
+    it 'raises when no stack is found' do
+      cfn.stub_responses(:describe_stacks, { stacks: [] })
+      expect { discover_cfn_stack_context(cfn, { instance: 'api', environment: 'beta1' }) }
+        .to(raise_error(RuntimeError, /Unable to describe stack/))
+    end
+  end
+
+  describe '#discover_load_balancer' do
+    let(:elb) { Aws::ElasticLoadBalancingV2::Client.new(stub_responses: true) }
+
+    context 'when instance is load-balanced' do
+      before do
+        allow(Aws::ElasticLoadBalancingV2::Client).to(receive(:new).and_return(elb))
+        elb.stub_responses(:describe_target_groups, { target_groups: [{ target_group_arn: 'arn:beta1-80', target_group_name: 'beta1-80' }] })
+      end
+
+      it 'returns the ELB client and the target group arn', :aggregate_failures do
+        client, arn = discover_load_balancer({ instance: 'api', environment: 'beta1' })
+        expect(client).to(be(elb))
+        expect(arn).to(eq('arn:beta1-80'))
+      end
+    end
+
+    context 'when instance is not load-balanced' do
+      before { allow(Aws::ElasticLoadBalancingV2::Client).to(receive(:new)) }
+
+      it 'returns [nil, nil]' do
+        expect(discover_load_balancer({ instance: 'worker' })).to(eq([nil, nil]))
+      end
+
+      it 'does not instantiate an ELB client' do
+        discover_load_balancer({ instance: 'worker' })
+        expect(Aws::ElasticLoadBalancingV2::Client).not_to(have_received(:new))
+      end
+    end
+  end
+
+  describe '#parse_deploy_options' do
+    it 'parses mandatory and optional arguments', :aggregate_failures do
+      options = parse_deploy_options(%w[--environment beta1 --instance api --profile dev --ami ami-abc])
+      expect(options[:environment]).to(eq('beta1'))
+      expect(options[:instance]).to(eq('api'))
+      expect(options[:profile]).to(eq('dev'))
+      expect(options[:ami]).to(eq('ami-abc'))
+    end
+
+    it 'raises when a mandatory argument is missing' do
+      expect { parse_deploy_options(%w[--environment beta1 --instance api]) }
+        .to(raise_error(OptionParser::MissingArgument, /profile/))
+    end
+  end
+
+  describe '#warm_up_after_scale_up' do
+    let(:elb) { Aws::ElasticLoadBalancingV2::Client.new(stub_responses: true) }
+
+    before { allow(self).to(receive(:sleep)) }
+
+    context 'with grpc instance' do
+      before { elb.stub_responses(:describe_target_health, { target_health_descriptions: [{ target: { id: 'i-1' }, target_health: { state: 'healthy' } }] }) }
+
+      it 'sleeps WARMUP_SHORT then waits for healthy then sleeps WARMUP_LONG', :aggregate_failures do
+        warm_up_after_scale_up(elb, 'arn:tg', { instance: 'grpc' })
+        expect(self).to(have_received(:sleep).with(WARMUP_SHORT))
+        expect(self).to(have_received(:sleep).with(WARMUP_LONG))
+      end
+    end
+
+    context 'with worker instance (not load-balanced)' do
+      it 'skips ELB checks and sleeps WARMUP_SHORT', :aggregate_failures do
+        warm_up_after_scale_up(nil, nil, { instance: 'worker' })
+        expect(self).to(have_received(:sleep).with(WARMUP_SHORT))
+      end
+    end
+  end
+
+  describe '#scale_down_after_deploy' do
+    let(:asg_resources) { instance_double(Aws::AutoScaling::Resource, client: asg_client) }
+    let(:asg_client)    { Aws::AutoScaling::Client.new(stub_responses: true)          }
+    let(:asg)           { { name: 'beta1-api-asg', desired_capacity: 2, max_size: 4 } }
+    let(:mixed_params)  { { base_capacity: '0', percent_above: '50' }                 }
+
+    before do
+      allow(self).to(receive(:sleep))
+      allow(asg_client).to(receive(:update_auto_scaling_group).and_call_original)
+    end
+
+    context 'when --skip_scale_down' do
+      it 'sets max_size and skips scale-down wait', :aggregate_failures do
+        scale_down_after_deploy(asg_resources, asg, mixed_params, 6, nil, nil, { instance: 'worker', skip_scale_down: true })
+        expect(asg_client).to(have_received(:update_auto_scaling_group).with(hash_including(max_size: 4)))
+      end
+    end
+
+    context 'with load-balanced instance' do
+      before do
+        asg_client.stub_responses(:describe_auto_scaling_groups, build_asg_data('beta1-api-asg', instances: [build_asg_instance('i-1'), build_asg_instance('i-2')]))
+      end
+
+      it 'restores desired capacity and waits for healthy + count', :aggregate_failures do
+        elb = Aws::ElasticLoadBalancingV2::Client.new(stub_responses: true)
+        elb.stub_responses(:describe_target_health, { target_health_descriptions: [{ target: { id: 'i-1' }, target_health: { state: 'healthy' } }] })
+        scale_down_after_deploy(asg_resources, asg, mixed_params, 6, elb, 'arn:tg', { instance: 'api' })
+        expect(asg_client).to(have_received(:update_auto_scaling_group).with(hash_including(desired_capacity: 2, max_size: 4)))
+      end
+    end
+  end
+
+  describe '#run_rolling_deploy' do
+    let(:asg_resources) { instance_double(Aws::AutoScaling::Resource, client: asg_client) }
+    let(:asg_client)    { Aws::AutoScaling::Client.new(stub_responses: true)          }
+    let(:asg)           { { name: 'beta1-api-asg', desired_capacity: 2, max_size: 4 } }
+    let(:mixed_params)  { { base_capacity: '0', percent_above: '50' }                 }
+
+    before do
+      allow(self).to(receive(:sleep))
+      allow(asg_client).to(receive(:update_auto_scaling_group).and_call_original)
+      asg_client.stub_responses(:describe_auto_scaling_groups, build_asg_data('beta1-api-asg', instances: [build_asg_instance('i-1'), build_asg_instance('i-2')]))
+    end
+
+    it 'always restores the mixed-instances policy via ensure' do
+      captured_params = []
+      allow(asg_client).to(receive(:update_auto_scaling_group)) { |params| captured_params << params }
+      run_rolling_deploy(asg_resources, asg, mixed_params, 2, nil, nil, { instance: 'worker' })
+      expect(captured_params.last.dig(:mixed_instances_policy, :instances_distribution, :on_demand_percentage_above_base_capacity)).to(eq('50'))
+    end
+
+    it 'still restores policy when scale-up wait raises', :aggregate_failures do
+      stub_const('MAX_POLL_ATTEMPTS', 1)
+      asg_client.stub_responses(:describe_auto_scaling_groups, build_asg_data('beta1-api-asg', instances: [build_asg_instance('i-1')]))
+      expect { run_rolling_deploy(asg_resources, asg, mixed_params, 6, nil, nil, { instance: 'worker' }) }
+        .to(raise_error(RuntimeError, /Timed out/))
+      expect(asg_client).to(have_received(:update_auto_scaling_group).with(hash_including(mixed_instances_policy: hash_including(instances_distribution: hash_including(on_demand_percentage_above_base_capacity: '50')))))
+    end
+  end
+
+  describe '#run_deployment' do
+    let(:lambda_client) { Aws::Lambda::Client.new(stub_responses: true)     }
+    let(:cloudfront)    { Aws::CloudFront::Client.new(stub_responses: true) }
+
+    context 'with --lambda_publish_version' do
+      before do
+        allow(Aws::Lambda::Client).to(receive(:new).and_return(lambda_client))
+        allow(Aws::CloudFront::Client).to(receive(:new).and_return(cloudfront))
+        allow(lambda_client).to(receive(:publish_version).and_call_original)
+        lambda_client.stub_responses(:publish_version, { function_arn: 'arn:aws:lambda:us-east-1:123:function:my-function:1' })
+        dist_item = build_distribution_item(default_cache_behavior: { target_origin_id: 'origin1', viewer_protocol_policy: 'redirect-to-https', allowed_methods: { quantity: 2, items: %w[GET HEAD] }, forwarded_values: { query_string: false, cookies: { forward: 'none' } }, min_ttl: 0, lambda_function_associations: { quantity: 0, items: [] } })
+        cloudfront.stub_responses(:list_distributions, build_distribution_list([dist_item]))
+        cloudfront.stub_responses(:get_distribution_config, build_cf_config)
+      end
+
+      it 'runs the lambda branch without touching ASG/CFN' do
+        run_deployment({ environment: 'beta', instance: 'api', profile: 'dev', lambda_publish_version: 'my-function' })
+        expect(lambda_client).to(have_received(:publish_version))
       end
     end
   end


### PR DESCRIPTION
## Summary

Five code-quality refactors that flatten the largest god-block in `deploy.rb`, extract the credentials-cycling main loop in `cycle-keys.rb`, eliminate three identical polling loops, split a method that combined a mutation side-effect with a pure update, and compress the duplicated install stanzas in the `linters` bash script. No behavior change — all existing tests still pass, plus new tests for every extracted helper.

**Key changes:**

- `deploy.rb`: extracted `poll_until(description:, max_attempts:, interval:)` and rewrote `wait_for_healthy_instances`, `wait_for_asg_instance_count`, and `wait_for_stack_update` on top of it; three near-identical loops collapsed to one helper.
- `deploy.rb`: split `update_ssm_parameters` into a pure SSM-update method plus an explicit `mark_cfn_secrets_for_previous_value!` so the array-mutation side effect is no longer hidden by the SSM-update name. Introduced `CFN_SECRET_PARAMETERS` constant.
- `deploy.rb`: extracted the 149-line `if __FILE__ == $PROGRAM_NAME` orchestrator into testable methods — `resolve_capacity_factors`, `compute_asg_capacity_plan`, `resolve_ami_id`, `discover_cfn_stack_context`, `discover_load_balancer`, `warm_up_after_scale_up`, `scale_down_after_deploy`, `run_rolling_deploy`, `run_deployment`, and `parse_deploy_options(argv)`. The remaining `:nocov:` block is now ~7 lines (parse + dispatch + top-level rescue).
- `cycle-keys.rb`: extracted `process_credential_profile`, `find_primary_key_user`, `build_iam_client`, `run_cycle_keys`, and `parse_cycle_keys_options(argv)`. Introduced `KEY_AGE_DAYS_THRESHOLD = 80` constant (was a magic number). The `:nocov:` block shrinks to ~7 lines.
- `linters`: extracted `is_darwin`, `sudo_for_user_command`, and `find_lintable` helpers to compress the triplicate `SUDO=""/SUDO="sudo"` block and the byte-identical `find … -not -path …` filter that appeared twice.
- `spec/deploy_spec.rb`: added RSpec coverage for the 10 new top-level methods.
- `spec/cycle_keys_spec.rb`: added RSpec coverage for `find_primary_key_user`, `parse_cycle_keys_options`, and the four control-flow paths of `process_credential_profile` (error, no_keys, username_mismatch, too_young).

Errors from the Ruby orchestrators now go to STDERR via `warn` instead of STDOUT via `puts`.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified