### PR TITLE
Fix silent failures in sync-jira-release, encrypt-logs, and cycle-keys

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -42,11 +42,23 @@ def create_and_save_new_key(iam, credentials, profile, user_name, credentials_fi
   credentials[profile]['aws_access_key_id'] = response.access_key.access_key_id
   credentials[profile]['aws_secret_access_key'] = response.access_key.secret_access_key
 
-  # Use file locking to prevent race conditions when multiple instances run simultaneously
-  File.open("#{credentials_file_name}.lock", File::RDWR | File::CREAT, 0o600) do |lock_file|
-    lock_file.flock(File::LOCK_EX)
-    credentials.save
-    puts("\tNew key saved into: #{credentials_file_name}")
+  begin
+    # Use file locking to prevent race conditions when multiple instances run simultaneously
+    File.open("#{credentials_file_name}.lock", File::RDWR | File::CREAT, 0o600) do |lock_file|
+      lock_file.flock(File::LOCK_EX)
+      credentials.save
+      puts("\tNew key saved into: #{credentials_file_name}")
+    end
+  rescue StandardError => e
+    puts("\tFailed to persist new key to #{credentials_file_name}, deleting #{new_access_key_id} from AWS...")
+    begin
+      iam.delete_access_key({ access_key_id: new_access_key_id, user_name: user_name })
+      puts("\tCleanup succeeded: #{new_access_key_id} was deleted")
+    rescue StandardError => cleanup_error
+      puts("\tWARNING: manual cleanup required — orphaned key #{new_access_key_id} for #{user_name}")
+      pp(cleanup_error)
+    end
+    raise(e)
   end
 
   new_access_key_id

--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -58,8 +58,10 @@ def process_log_group(logs, log_group, keys, retention_in_days)
       keys[:beta]
     elsif log_group[:log_group_name].include?('rc')
       keys[:rc]
-    else
+    elsif log_group[:log_group_name].include?('prod')
       keys[:prod]
+    else
+      raise("Cannot infer KMS environment from log group '#{log_group[:log_group_name]}'; expected name to contain 'beta', 'rc', or 'prod'")
     end
 
   puts("Encrypting #{log_group[:log_group_name]} with key = #{key}...")

--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -103,6 +103,39 @@ RSpec.describe(CycleKeys) do
       expect(cred_hash['aws_access_key_id']).to(eq('AKIANEWKEY123'))
       expect(cred_hash['aws_secret_access_key']).to(eq('secret123'))
     end
+
+    context 'when credentials.save raises' do
+      before do
+        allow(credentials).to(receive(:save).and_raise(Errno::EACCES.new('permission denied')))
+        allow(iam).to(receive(:delete_access_key).and_call_original)
+      end
+
+      it 're-raises the disk error after cleanup' do
+        expect { create_and_save_new_key(iam, credentials, 'test-profile', user_name, '/tmp/test-credentials') }
+          .to(raise_error(Errno::EACCES))
+      end
+
+      it 'deletes the orphaned AWS key' do
+        begin
+          create_and_save_new_key(iam, credentials, 'test-profile', user_name, '/tmp/test-credentials')
+        rescue Errno::EACCES
+          # expected; we want to inspect side effects after the raise
+        end
+        expect(iam).to(have_received(:delete_access_key).with(hash_including(access_key_id: 'AKIANEWKEY123', user_name: user_name)))
+      end
+    end
+
+    context 'when credentials.save raises and cleanup also fails' do
+      before do
+        allow(credentials).to(receive(:save).and_raise(Errno::EACCES.new('permission denied')))
+        allow(iam).to(receive(:delete_access_key).and_raise(Aws::IAM::Errors::ServiceError.new(nil, 'cleanup failed')))
+      end
+
+      it 'still re-raises the original disk error' do
+        expect { create_and_save_new_key(iam, credentials, 'test-profile', user_name, '/tmp/test-credentials') }
+          .to(raise_error(Errno::EACCES))
+      end
+    end
   end
 
   describe '#rollback_key_change' do

--- a/spec/encrypt_logs_spec.rb
+++ b/spec/encrypt_logs_spec.rb
@@ -115,12 +115,21 @@ RSpec.describe(EncryptLogs) do
       end
     end
 
-    context 'with unencrypted non-beta non-rc log group' do
-      let(:log_group) { { log_group_name: '/aws/production/api', retention_in_days: 30, kms_key_id: nil } }
+    context 'with unencrypted prod log group' do
+      let(:log_group) { { log_group_name: '/aws/prod/api', retention_in_days: 30, kms_key_id: nil } }
 
       it 'encrypts with prod key' do
         process_log_group(logs, log_group, keys, retention_in_days)
         expect(logs).to(have_received(:associate_kms_key).with(hash_including(kms_key_id: 'arn:prod-key')))
+      end
+    end
+
+    context 'with log group name that matches no known environment' do
+      let(:log_group) { { log_group_name: '/aws/staging/api', retention_in_days: 30, kms_key_id: nil } }
+
+      it 'raises rather than silently falling back to the prod KMS key' do
+        expect { process_log_group(logs, log_group, keys, retention_in_days) }
+          .to(raise_error(RuntimeError, /Cannot infer KMS environment/))
       end
     end
 

--- a/sync-jira-release
+++ b/sync-jira-release
@@ -174,13 +174,24 @@ done
 
 sort "${temp_file}" | uniq > "${temp_file}_unique"
 
+FAILED_ISSUES=()
+
 # shellcheck disable=SC2013
 for issue_key in $(cat "${temp_file}_unique"); do
   echo "Updating issue ${issue_key}..."
-  jira issue edit "${issue_key}" --no-input --fix-version "${3}" || true
+  if ! jira issue edit "${issue_key}" --no-input --fix-version "${3}"; then
+    echo "Warning: failed to update ${issue_key}" >&2
+    FAILED_ISSUES+=("${issue_key}")
+  fi
 done
 
 rm -f "${temp_file}" "${temp_file}_unique"
+
+if [ ${#FAILED_ISSUES[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "Error: ${#FAILED_ISSUES[@]} issue(s) failed to update: ${FAILED_ISSUES[*]}" >&2
+  exit 1
+fi
 
 echo ""
 echo "Done! Opening release report for review..."


### PR DESCRIPTION
## Summary

Three independent bug fixes that close silent-failure paths flagged in the recent code review. Each one converts a "succeed-anyway" branch into either a fail-loud raise or an explicit cleanup + re-raise.

**Key changes:**

- `sync-jira-release`: replace `jira issue edit … || true` with a per-issue conditional that logs each failure to stderr, accumulates the list of failed issue keys, and exits non-zero with a summary if any issue failed to update. The script no longer silently reports success after partial failures (BUG-004).
- `cycle-keys.rb`: wrap the `credentials.save` block in `create_and_save_new_key` so that if writing to `~/.aws/credentials` fails after `iam.create_access_key` succeeded, the freshly created IAM key is deleted from AWS before the disk error is re-raised. Closes the orphaned-key window that could exhaust the AWS 2-keys-per-user limit on repeated rotation failures (BUG-008).
- `encrypt-logs.rb`: in `process_log_group`, raise instead of silently falling back to the prod KMS key when a log group's name contains neither `beta`, `rc`, nor `prod`. Prevents future log groups (e.g. `staging`, `qa`) from being encrypted with the wrong key (BUG-009).
- `spec/cycle_keys_spec.rb`: 3 new examples cover the disk-save failure path — re-raise, cleanup-deletes-AWS-key, and cleanup-also-fails-still-raises-original.
- `spec/encrypt_logs_spec.rb`: replaced the `non-beta non-rc` test that asserted on the silent prod fallback with one that asserts on the new raise; added a happy-path `prod` test alongside.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified