### PR TITLE
Clean up encrypt-logs.rb: dedupe env classification, fix install comment, use STDERR

### DIFF
--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -1,8 +1,5 @@
 #!/usr/bin/env ruby
 #
-# to install just run
-#     gem install aws-sdk
-#
 # https://docs.aws.amazon.com/sdk-for-ruby
 
 # frozen_string_literal: true
@@ -11,6 +8,12 @@ require 'aws-sdk-cloudwatchlogs'
 require 'aws-sdk-core'
 require 'aws-sdk-kms'
 require 'optparse'
+
+KMS_ENVIRONMENTS = %i[beta rc prod].freeze
+
+def infer_environment(string)
+  KMS_ENVIRONMENTS.find { |env| string.include?(env.to_s) }
+end
 
 def build_kms_key_map(kms)
   keys = {}
@@ -22,18 +25,12 @@ def build_kms_key_map(kms)
           key_id: key.key_id
         }
       )
-
-      if key_metadata[:key_metadata][:description].start_with?('beta')
-        keys[:beta] = key_metadata[:key_metadata][:arn]
-      elsif key_metadata[:key_metadata][:description].start_with?('rc')
-        keys[:rc] = key_metadata[:key_metadata][:arn]
-      elsif key_metadata[:key_metadata][:description].start_with?('prod')
-        keys[:prod] = key_metadata[:key_metadata][:arn]
-      end
+      env = KMS_ENVIRONMENTS.find { |candidate| key_metadata[:key_metadata][:description].start_with?(candidate.to_s) }
+      keys[env] = key_metadata[:key_metadata][:arn] if env
     end
   end
 
-  %i[beta rc prod].each do |env|
+  KMS_ENVIRONMENTS.each do |env|
     raise("KMS key not found for environment '#{env}'") if keys[env].nil?
   end
 
@@ -53,17 +50,10 @@ def process_log_group(logs, log_group, keys, retention_in_days)
 
   return if log_group[:kms_key_id]
 
-  key =
-    if log_group[:log_group_name].include?('beta')
-      keys[:beta]
-    elsif log_group[:log_group_name].include?('rc')
-      keys[:rc]
-    elsif log_group[:log_group_name].include?('prod')
-      keys[:prod]
-    else
-      raise("Cannot infer KMS environment from log group '#{log_group[:log_group_name]}'; expected name to contain 'beta', 'rc', or 'prod'")
-    end
+  env = infer_environment(log_group[:log_group_name])
+  raise("Cannot infer KMS environment from log group '#{log_group[:log_group_name]}'; expected name to contain one of #{KMS_ENVIRONMENTS.join(', ')}") if env.nil?
 
+  key = keys[env]
   puts("Encrypting #{log_group[:log_group_name]} with key = #{key}...")
   logs.associate_kms_key(
     {
@@ -113,8 +103,8 @@ if __FILE__ == $PROGRAM_NAME
       end
     end
   rescue StandardError => e
-    puts(e)
-    puts(e.backtrace)
+    warn(e)
+    warn(e.backtrace)
     exit(1)
   end
 end


### PR DESCRIPTION
## Summary

Three small cleanups in `encrypt-logs.rb` flagged in the code review. No behavior change in the happy path; the unknown-env raise added in #464 continues to fire.

**Key changes:**

- Replace the duplicated env-dispatch (`start_with?` chain in `build_kms_key_map`, `include?` chain in `process_log_group`) with a shared `KMS_ENVIRONMENTS` constant and an `infer_environment` helper. Adding a new env now means appending one symbol to the constant rather than editing two if/elsif chains (QUAL-010).
- Remove the misleading `# gem install aws-sdk` install hint from lines 3-4. The script only requires `aws-sdk-cloudwatchlogs`, `aws-sdk-core`, and `aws-sdk-kms`; the `aws-sdk` meta-gem would pull ~400 service gems unnecessarily (QUAL-011).
- Replace `puts(e); puts(e.backtrace)` with `warn(e); warn(e.backtrace)` in the top-level rescue so errors land on STDERR like every other CLI in this repo (BUG-011).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: All 12 existing examples in spec/encrypt_logs_spec.rb continue to pass — they cover both refactored dispatch sites and the unknown-env raise that was tightened in #464.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified