### PR TITLE
Clean up brew-resources.rb: better HTTP error context and use STDERR

### DIFF
--- a/brew-resources.rb
+++ b/brew-resources.rb
@@ -49,16 +49,17 @@ if __FILE__ == $PROGRAM_NAME
     lock_file = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock'))
 
     lock_file.specs.each do |spec|
-      response = HTTParty.get("https://rubygems.org/gems/#{spec.full_name}.gem")
+      url = "https://rubygems.org/gems/#{spec.full_name}.gem"
+      response = HTTParty.get(url)
 
-      raise(response.message) unless response.code == 200
+      raise("rubygems.org returned HTTP #{response.code} for #{url}: #{response.message} — #{response.body.to_s[0, 200]}") unless response.code == 200
 
       sha256 = Digest::SHA256.hexdigest(response.body)
       format_resource(spec, sha256).each { |line| puts(line) }
     end
   rescue StandardError => e
-    puts(e)
-    puts(e.backtrace)
+    warn(e)
+    warn(e.backtrace)
     exit(1)
   end
 end


### PR DESCRIPTION
## Summary

Two small cleanups in `brew-resources.rb` flagged in the code review.

**Key changes:**

- The HTTP error path used to raise `response.message` only (e.g. `"Internal Server Error"`), discarding the status code, the URL being fetched, and the response body. The new message includes all four so a transient 5xx mid-run actually tells you which gem failed and why (BUG-010).
- Replace `puts(e); puts(e.backtrace)` with `warn(e); warn(e.backtrace)` so errors land on STDERR like every other CLI in this repo (BUG-011).

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: The HTTParty call path is inside the \`:nocov:\` orchestration block (TEST-012 — adding webmock is tracked separately); existing 7 examples in spec/brew_resources_spec.rb continue to pass.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified