### PR TITLE
Doc cleanup: README binary prereqs and remove architecture filler row

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,26 @@ This is a collection of tools to run locally or on a CI pipeline. These tools ar
 
 ## Installation
 
-Prerequisites are Ruby >= 4.0 and Bundler.
+Required:
 
-Run `bundle install` to install dependencies, then run the commands.
+* Ruby >= 4.0 and Bundler — for `deploy.rb`, `cycle-keys.rb`, `encrypt-logs.rb`, `brew-resources.rb`
+
+Required by individual scripts:
+
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) — `ssm-jump`
+* [jq](https://jqlang.github.io/jq/) — `ssm-jump`
+* [GitHub CLI (`gh`)](https://cli.github.com/) — `sync-jira-release` (the `jira` CLI is auto-installed on first run)
+
+Run `bundle install` to install Ruby dependencies, then run the commands.
 
 ### Verification
 
 ```bash
 ruby --version
 bundle --version
+aws --version
+jq --version
+gh --version
 ```
 
 You can install via [Homebrew](https://github.com/Cloud-Officer/homebrew-ci).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -374,12 +374,11 @@ All SOUP data is managed in [.soup.json](../.soup.json). The `soup.md` file is a
 
 ### Operational Safety
 
-| Control              | Implementation                                | Location                                        |
-|----------------------|-----------------------------------------------|-------------------------------------------------|
-| Capacity Limits      | Respects ASG max_size constraints             | `deploy.rb` in ASG update section               |
-| Health Checks        | Waits for ELB target health before proceeding | `deploy.rb` in `wait_for_healthy_instances`     |
-| Warm-up Periods      | Configurable sleep times for cache warming    | `deploy.rb` in cache warm-up section            |
-| Deprecation Warnings | Clear warnings for deprecated tools           | N/A (no deprecated tools currently)             |
+| Control         | Implementation                                | Location                                    |
+|-----------------|-----------------------------------------------|---------------------------------------------|
+| Capacity Limits | Respects ASG max_size constraints             | `deploy.rb` in ASG update section           |
+| Health Checks   | Waits for ELB target health before proceeding | `deploy.rb` in `wait_for_healthy_instances` |
+| Warm-up Periods | Configurable sleep times for cache warming    | `deploy.rb` in cache warm-up section        |
 
 ### Logging and Monitoring
 


### PR DESCRIPTION
## Summary

Two small documentation fixes flagged in the code review.

**Key changes:**

- `README.md`: the Installation section previously listed only Ruby and Bundler as prerequisites, but `ssm-jump` needs `aws` + `jq` and `sync-jira-release` needs `gh`. First-time users following the README hit cryptic runtime errors. Now the prereqs section spells out which binaries each script needs, and the Verification block runs `--version` on each (DOC-003).
- `docs/architecture.md`: removed the "Deprecation Warnings | N/A (no deprecated tools currently)" row from the Operational Safety table. Listing a control whose implementation is N/A is filler — either commit to implementing it or remove the row (DOC-007).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Documentation-only changes; markdownlint-cli2 passes locally.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [x] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [x] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified