### PR TITLE
Extract shared lib/cli_main for rescue/exit + OptionParser scaffolds

### DIFF
--- a/brew-resources.rb
+++ b/brew-resources.rb
@@ -5,6 +5,7 @@
 require 'bundler'
 require 'digest'
 require 'httparty'
+require_relative 'lib/cli_main'
 
 def format_resource(spec, sha256)
   lines = []
@@ -45,7 +46,7 @@ end
 
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
-  begin
+  CliMain.run! do
     lock_file = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock'))
 
     lock_file.specs.each do |spec|
@@ -57,10 +58,6 @@ if __FILE__ == $PROGRAM_NAME
       sha256 = Digest::SHA256.hexdigest(response.body)
       format_resource(spec, sha256).each { |line| puts(line) }
     end
-  rescue StandardError => e
-    warn(e)
-    warn(e.backtrace)
-    exit(1)
   end
 end
 # :nocov:

--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -5,7 +5,7 @@
 require 'aws-sdk-iam'
 require 'date'
 require 'iniparse'
-require 'optparse'
+require_relative 'lib/cli_main'
 
 def cleanup_secondary_keys(iam, primary_key_id, metadata_list)
   metadata_list.each do |key_metadata|
@@ -184,13 +184,7 @@ def disable_and_delete_old_key(iam, access_key, user_name, rollback)
 end
 
 def parse_cycle_keys_options(argv = ARGV)
-  options = {}
-
-  OptionParser.new do |opts|
-    opts.banner = 'Usage: cycle-keys.rb options'
-    opts.separator('')
-    opts.separator('options')
-
+  CliMain.parse_options!(banner: 'Usage: cycle-keys.rb options', mandatory: %i[profile username], argv: argv) do |opts|
     opts.on('--profile profile', String)
     opts.on('--username username', String)
     opts.on('--force')
@@ -198,13 +192,7 @@ def parse_cycle_keys_options(argv = ARGV)
       puts(opts)
       exit(1)
     end
-  end.parse!(argv, into: options)
-
-  mandatory = %i[profile username]
-  missing = mandatory.select { |param| options[param].nil? }
-  raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
-
-  options
+  end
 end
 
 def run_cycle_keys(options)
@@ -227,12 +215,8 @@ end
 
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
-  begin
+  CliMain.run! do
     run_cycle_keys(parse_cycle_keys_options)
-  rescue StandardError => e
-    warn(e)
-    warn(e.backtrace)
-    exit(1)
   end
 end
 # :nocov:

--- a/deploy.rb
+++ b/deploy.rb
@@ -12,7 +12,7 @@ require 'aws-sdk-ec2'
 require 'aws-sdk-elasticloadbalancingv2'
 require 'aws-sdk-lambda'
 require 'aws-sdk-ssm'
-require 'optparse'
+require_relative 'lib/cli_main'
 
 # Timing constants for polling and warmup periods
 POLL_INTERVAL = 15      # Seconds between status checks
@@ -448,12 +448,7 @@ def run_deployment(options)
 end
 
 def parse_deploy_options(argv = ARGV)
-  options = {}
-
-  OptionParser.new do |opts|
-    opts.banner = 'Usage: deploy.rb options'
-    opts.separator('')
-    opts.separator('options')
+  CliMain.parse_options!(banner: 'Usage: deploy.rb options', mandatory: %i[environment instance profile], argv: argv) do |opts|
     opts.on('--ami ami', String)
     opts.on('--create_ami_only')
     opts.on('--environment environment', String)
@@ -468,25 +463,15 @@ def parse_deploy_options(argv = ARGV)
       puts(opts)
       exit(0)
     end
-  end.parse!(argv, into: options)
-
-  mandatory = %i[environment instance profile]
-  missing = mandatory.select { |param| options[param].nil? }
-  raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
-
-  options
+  end
 end
 
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
-  begin
+  CliMain.run! do
     options = parse_deploy_options
     puts('Starting deployment...')
     run_deployment(options)
-  rescue StandardError => e
-    warn(e)
-    warn(e.backtrace)
-    exit(1)
   end
 end
 # :nocov:

--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -7,7 +7,7 @@
 require 'aws-sdk-cloudwatchlogs'
 require 'aws-sdk-core'
 require 'aws-sdk-kms'
-require 'optparse'
+require_relative 'lib/cli_main'
 
 KMS_ENVIRONMENTS = %i[beta rc prod].freeze
 
@@ -63,49 +63,38 @@ def process_log_group(logs, log_group, keys, retention_in_days)
   )
 end
 
+def parse_encrypt_logs_options(argv = ARGV)
+  CliMain.parse_options!(banner: 'Usage: encrypt_logs.rb options', mandatory: %i[profile retention_in_days], argv: argv) do |opts|
+    opts.on('--profile profile', String)
+    opts.on('--retention_in_days retention_in_days', Integer)
+    opts.on('-h', '--help') do
+      puts(opts)
+      exit(1)
+    end
+  end
+end
+
+def run_encrypt_logs(options)
+  if options[:profile]
+    puts('Setting profile...')
+    Aws.config.update({ profile: options[:profile] })
+  end
+
+  kms = Aws::KMS::Client.new
+  keys = build_kms_key_map(kms)
+  logs = Aws::CloudWatchLogs::Client.new
+
+  logs.describe_log_groups.each_page do |page|
+    page.log_groups.each do |log_group|
+      process_log_group(logs, log_group, keys, options[:retention_in_days])
+    end
+  end
+end
+
 # :nocov:
 if __FILE__ == $PROGRAM_NAME
-  begin
-    # parse command line options
-
-    options = {}
-
-    OptionParser.new do |opts|
-      opts.banner = 'Usage: encrypt_logs.rb options'
-      opts.separator('')
-      opts.separator('options')
-
-      opts.on('--profile profile', String)
-      opts.on('--retention_in_days retention_in_days', Integer)
-      opts.on('-h', '--help') do
-        puts(opts)
-        exit(1)
-      end
-    end.parse!(into: options)
-
-    mandatory = %i[profile retention_in_days]
-    missing = mandatory.select { |param| options[param].nil? }
-    raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
-
-    if options[:profile]
-      puts('Setting profile...')
-      Aws.config.update({ profile: options[:profile] })
-    end
-
-    kms = Aws::KMS::Client.new
-    keys = build_kms_key_map(kms)
-
-    logs = Aws::CloudWatchLogs::Client.new
-
-    logs.describe_log_groups.each_page do |page|
-      page.log_groups.each do |log_group|
-        process_log_group(logs, log_group, keys, options[:retention_in_days])
-      end
-    end
-  rescue StandardError => e
-    warn(e)
-    warn(e.backtrace)
-    exit(1)
+  CliMain.run! do
+    run_encrypt_logs(parse_encrypt_logs_options)
   end
 end
 # :nocov:

--- a/lib/cli_main.rb
+++ b/lib/cli_main.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+# Shared helpers used by the top-level scripts in this repo.
+module CliMain
+  # Wraps a CLI's main block: catches any uncaught StandardError, prints
+  # the error + backtrace to STDERR, and exits 1. Use it instead of repeating
+  # `rescue StandardError => e; warn(e); warn(e.backtrace); exit(1)` at the
+  # bottom of every script.
+  def self.run!
+    yield
+  rescue StandardError => e
+    warn(e)
+    warn(e.backtrace)
+    exit(1)
+  end
+
+  # Builds an OptionParser, hands it to the caller's block for script-specific
+  # opts.on calls, parses argv, then enforces a mandatory-keys check. Returns
+  # the parsed options hash.
+  def self.parse_options!(banner:, mandatory:, argv: ARGV)
+    options = {}
+
+    OptionParser.new do |opts|
+      opts.banner = banner
+      opts.separator('')
+      opts.separator('options')
+      yield(opts)
+    end.parse!(argv, into: options)
+
+    missing = mandatory.select { |param| options[param].nil? }
+    raise(OptionParser::MissingArgument, missing.join(', ')) unless missing.empty?
+
+    options
+  end
+end

--- a/spec/cli_main_spec.rb
+++ b/spec/cli_main_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../lib/cli_main'
+
+RSpec.describe(CliMain) do
+  describe '.run!' do
+    it 'yields and returns the block result on success' do
+      expect(described_class.run! { 42 }).to(eq(42))
+    end
+
+    it 'catches StandardError, writes to STDERR, and exits 1', :aggregate_failures do
+      expect do
+        expect { described_class.run! { raise(StandardError, 'boom') } }
+          .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+      end.to(output(/boom/).to_stderr)
+    end
+
+    it 'does not catch SystemExit or other non-StandardError errors', :aggregate_failures do
+      expect { described_class.run! { raise(SystemExit, 0) } }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+    end
+  end
+
+  describe '.parse_options!' do
+    it 'returns the parsed options hash' do
+      result =
+        described_class.parse_options!(banner: 'Usage: x', mandatory: %i[name], argv: %w[--name foo]) do |opts|
+          opts.on('--name name', String)
+        end
+      expect(result).to(eq(name: 'foo'))
+    end
+
+    it 'raises MissingArgument when a mandatory key is absent' do
+      expect do
+        described_class.parse_options!(banner: 'Usage: x', mandatory: %i[name], argv: []) do |opts|
+          opts.on('--name name', String)
+        end
+      end.to(raise_error(OptionParser::MissingArgument, /name/))
+    end
+
+    it 'mutates the supplied argv (parse! contract)' do
+      argv = %w[--name foo unconsumed]
+      described_class.parse_options!(banner: 'Usage: x', mandatory: %i[name], argv: argv) do |opts|
+        opts.on('--name name', String)
+      end
+      expect(argv).to(eq(%w[unconsumed]))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require_relative '../brew-resources'
 require_relative '../cycle-keys'
 require_relative '../deploy'
 require_relative '../encrypt-logs'
+require_relative '../lib/cli_main'
 
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
## Summary

Extracts two duplicated patterns into a new `lib/cli_main.rb` module:

1. The four-line `rescue StandardError => e / warn(e) / warn(e.backtrace) / exit(1)` epilogue that previously appeared identically in `deploy.rb`, `cycle-keys.rb`, `encrypt-logs.rb`, and `brew-resources.rb`.
2. The OptionParser-plus-mandatory-check scaffold that previously appeared in `deploy.rb`, `cycle-keys.rb`, and (still inlined inside `:nocov:`) `encrypt-logs.rb`.

No behavior change — all 149 existing examples still pass; 6 new examples cover the new module directly.

**Key changes:**

- New `lib/cli_main.rb` with two module methods: `CliMain.run!` (wraps a main block in the standard rescue/exit) and `CliMain.parse_options!(banner:, mandatory:, argv:)` (yields the OptionParser to the caller, then enforces mandatory keys) (QUAL-008, QUAL-009).
- `deploy.rb`, `cycle-keys.rb`, `encrypt-logs.rb`, `brew-resources.rb`: collapse the four duplicate epilogues into single `CliMain.run! do ... end` calls inside their `:nocov:` blocks. Replace the three duplicate OptionParser scaffolds with `CliMain.parse_options!` calls. `encrypt-logs.rb` additionally gets `parse_encrypt_logs_options` and `run_encrypt_logs` extracted out of `:nocov:` so the orchestrator shrinks to four lines.
- `spec/spec_helper.rb`: load the new lib alongside the existing scripts.
- `spec/cli_main_spec.rb`: 6 new examples covering the success path, StandardError → STDERR + exit(1), passthrough of non-StandardError, return value of `parse_options!`, the missing-arg raise, and the `parse!` argv-mutation contract.

Net diff: 83 lines deleted, 125 lines added (most of the addition is the new lib + spec).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] \`readme.md\` includes sections on introduction, installation, usage, and contributing
- [ ] \`docs/architecture.md\` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified