### PR TITLE
Fix cycle-keys guard ordering and rollback re-activate; cli_main full_message

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -76,6 +76,23 @@ def rollback_key_change(iam, credentials, profile, user_name, credentials_file_n
     )
     puts("\tRollback: deleted new key")
 
+    # The disable step may already have flipped the original key to Inactive.
+    # Re-Activate it before restoring credentials on disk so the user is not
+    # left holding a credentials file that points at a disabled key.
+    begin
+      iam.update_access_key(
+        {
+          access_key_id: original_access_key,
+          status: 'Active',
+          user_name: user_name
+        }
+      )
+      puts("\tRollback: re-activated original key #{original_access_key}")
+    rescue StandardError => e
+      puts("\tWARNING: failed to re-activate original key #{original_access_key} - manual intervention required")
+      pp(e)
+    end
+
     credentials[profile]['aws_access_key_id'] = original_access_key
     credentials[profile]['aws_secret_access_key'] = original_secret_key
     File.open("#{credentials_file_name}.lock", File::RDWR | File::CREAT, 0o600) do |lock_file|
@@ -127,7 +144,6 @@ def process_credential_profile(credentials, profile, options)
   return :no_keys if response.access_key_metadata.none?
 
   user_name, age_days = find_primary_key_user(response.access_key_metadata, access_key)
-  cleanup_secondary_keys(iam, access_key, response.access_key_metadata)
 
   if user_name != options[:username]
     puts("\tUsername does not match: #{user_name}")
@@ -139,6 +155,9 @@ def process_credential_profile(credentials, profile, options)
     return :too_young
   end
 
+  # Cleanup runs only after the guards above - it is destructive (deletes
+  # any non-primary keys) and must not fire on no-op paths.
+  cleanup_secondary_keys(iam, access_key, response.access_key_metadata)
   new_access_key_id = create_and_save_new_key(iam, credentials, profile, user_name, credentials_file_name)
 
   rollback =

--- a/lib/cli_main.rb
+++ b/lib/cli_main.rb
@@ -6,13 +6,15 @@ require 'optparse'
 module CliMain
   # Wraps a CLI's main block: catches any uncaught StandardError, prints
   # the error + backtrace to STDERR, and exits 1. Use it instead of repeating
-  # `rescue StandardError => e; warn(e); warn(e.backtrace); exit(1)` at the
+  # `rescue StandardError => e; warn(e); warn(e.full_message); exit(1)` at the
   # bottom of every script.
   def self.run!
     yield
   rescue StandardError => e
-    warn(e)
-    warn(e.backtrace)
+    # full_message renders one frame per line AND walks the cause chain,
+    # unlike warn(e.backtrace) which inspect-joins the array onto one line
+    # and drops e.cause entirely.
+    warn(e.full_message)
     exit(1)
   end
 

--- a/spec/cli_main_spec.rb
+++ b/spec/cli_main_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe(CliMain) do
       end.to(output(/boom/).to_stderr)
     end
 
+    def raise_with_cause
+      raise(StandardError, 'inner')
+    rescue StandardError
+      raise(StandardError, 'outer')
+    end
+
+    it 'walks the cause chain and prints both messages via full_message', :aggregate_failures do
+      expect do
+        expect { described_class.run! { raise_with_cause } }
+          .to(raise_error(SystemExit))
+      end.to(output(/outer.*inner/m).to_stderr)
+    end
+
     it 'does not catch SystemExit or other non-StandardError errors', :aggregate_failures do
       expect { described_class.run! { raise(SystemExit, 0) } }
         .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })

--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -169,6 +169,19 @@ RSpec.describe(CycleKeys) do
       expect(cred_hash['aws_secret_access_key']).to(eq('oldsecret123'))
     end
 
+    it 're-activates the original key so the restored credentials are usable' do
+      allow(iam).to(receive(:update_access_key).and_call_original)
+      call_rollback
+      expect(iam).to(have_received(:update_access_key).with(hash_including(access_key_id: 'AKIAOLDKEY123', status: 'Active', user_name: 'testuser')))
+    end
+
+    it 'still restores credentials when re-activate fails', :aggregate_failures do
+      allow(iam).to(receive(:update_access_key).and_raise(Aws::IAM::Errors::ServiceError.new(nil, 'reactivate failed')))
+      expect { call_rollback }
+        .not_to(raise_error)
+      expect(credentials).to(have_received(:save))
+    end
+
     it 'swallows errors from delete_access_key without raising' do
       allow(iam).to(receive(:delete_access_key).and_raise(Aws::IAM::Errors::ServiceError.new(nil, 'API error')))
       expect { call_rollback }
@@ -299,20 +312,34 @@ RSpec.describe(CycleKeys) do
     context 'when the primary key user does not match' do
       before do
         iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'other', create_date: Time.now - (200 * 24 * 60 * 60), status: 'Active' }] })
+        allow(iam).to(receive(:delete_access_key))
+        allow(iam).to(receive(:update_access_key))
       end
 
       it 'returns :username_mismatch' do
         expect(process_credential_profile(credentials, 'dev', options)).to(eq(:username_mismatch))
+      end
+
+      it 'does not delete any keys (guards run before destructive cleanup)' do
+        process_credential_profile(credentials, 'dev', options)
+        expect(iam).not_to(have_received(:delete_access_key))
       end
     end
 
     context 'when the key is too young and --force is not set' do
       before do
         iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'alice', create_date: Time.now - (10 * 24 * 60 * 60), status: 'Active' }] })
+        allow(iam).to(receive(:delete_access_key))
+        allow(iam).to(receive(:update_access_key))
       end
 
       it 'returns :too_young' do
         expect(process_credential_profile(credentials, 'dev', options)).to(eq(:too_young))
+      end
+
+      it 'does not delete any keys (guards run before destructive cleanup)' do
+        process_credential_profile(credentials, 'dev', options)
+        expect(iam).not_to(have_received(:delete_access_key))
       end
     end
   end


### PR DESCRIPTION
## Summary

Addresses the three high-severity findings surfaced by the deep code review (`docs/code-review.md`). All three are correctness issues in shared CLI scaffolding or in the AWS key-rotation flow where a partial failure could leave an operator locked out, destroy backup keys on a no-op path, or hide the root cause of an error.

**Key changes:**

- `cycle-keys.rb` (BUG-002): `cleanup_secondary_keys` now runs only after the username and key-age guards. Previously a misconfigured `--username` or a `:too_young` skip would still delete every non-primary key for the user.
- `cycle-keys.rb` (BUG-003): `rollback_key_change` re-Activates the original AWS key before restoring the credentials file on disk, so a failure between the `Inactive` and `Delete` API calls no longer leaves the operator holding a credentials file that points at a disabled key.
- `lib/cli_main.rb` (BUG-032): `CliMain.run!` now prints `e.full_message` (one frame per line, walks `e.cause`) instead of `warn(e.backtrace)` which inspect-joined the backtrace onto a single comma-separated line and silently dropped the cause chain. This affects every Ruby CLI in the repo.
- `spec/cycle_keys_spec.rb`: regression tests for BUG-002 (no `delete_access_key` on `:username_mismatch` / `:too_young` paths) and BUG-003 (`update_access_key Active` is called against the original key during rollback; credentials still get saved if re-Activate itself fails).
- `spec/cli_main_spec.rb`: regression test verifying that wrapped exceptions surface both the outer and inner messages via `full_message`.

172 RSpec examples pass (5 new); RuboCop is clean across all 12 changed-or-adjacent files.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified