### PR TITLE
Fix Dockerfile to build from tagged build context instead of cloning master

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Keep the Git metadata and local cruft out of the image (ADD <git-url> previously dropped .git automatically)
+.git
+.gitignore
+.idea
+coverage
+*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN \
 # Add user/group citools and add ubuntu user to that group
 RUN useradd -m -s /bin/bash citools && echo 'citools ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers && adduser ubuntu citools
 
-# Clone the soup repository
-ADD https://github.com/Cloud-Officer/ci-tools.git /home/citools/ci-tools
+# Copy the checked-out source (build context is the tagged commit; .git excluded via .dockerignore)
+COPY . /home/citools/ci-tools
 
 # Install ci-tools dependencies and create a symlink
 USER root


### PR DESCRIPTION
## Summary

The Docker image previously sourced its application code with `ADD https://github.com/Cloud-Officer/ci-tools.git`, which clones the remote default branch (`master`) HEAD at build time. Because the image is published on tag push, the published image could contain code that does not match the tag it is labelled with, builds were non-reproducible, and image contents depended on a live external fetch with no commit pin or checksum (a supply-chain integrity gap).

The publish workflow already checks out the pushed tag (`actions/checkout@v6`) and builds with `context: .`, so the exact tagged source is already present in the build context. Switching to `COPY .` uses that verified source directly.

**Key changes:**

- `Dockerfile`: replace `ADD <git-url>` with `COPY . /home/citools/ci-tools`, so the image is built from the checked-out tagged commit instead of a live re-clone of `master`. This makes builds reproducible, guarantees the image matches its tag, removes the build-time network dependency, and correctly includes submodules/LFS.
- `.dockerignore` (new): exclude `.git` and local cruft so `COPY .` preserves prior behaviour (the old `ADD <git-url>` dropped `.git` automatically) and avoids bloating image layers.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dockerfile build-context change; validated with hadolint (clean) and exercised by the existing tag-triggered Docker publish workflow.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
