### PR TITLE
Cover the cycle-keys IAM rotation path with tests

### DIFF
--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -342,6 +342,82 @@ RSpec.describe(CycleKeys) do
         expect(iam).not_to(have_received(:delete_access_key))
       end
     end
+
+    context 'when the key is old enough and the username matches (rotation happy path)' do
+      let(:lock_file) { instance_double(File) }
+
+      before do
+        iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'alice', create_date: Time.now - (100 * 24 * 60 * 60), status: 'Active' }, { access_key_id: 'AKIASECONDARY', user_name: 'alice', create_date: Time.now - (100 * 24 * 60 * 60), status: 'Active' }] })
+        iam.stub_responses(:create_access_key, { access_key: { access_key_id: 'AKIANEWKEY123', secret_access_key: 'newsecret', user_name: 'alice', status: 'Active' } })
+        allow(iam).to(receive(:create_access_key).and_call_original)
+        allow(iam).to(receive(:update_access_key).and_call_original)
+        allow(iam).to(receive(:delete_access_key).and_call_original)
+        allow(credentials).to(receive(:save))
+        allow(File).to(receive(:open).with("#{Dir.home}/.aws/credentials.lock", anything, anything).and_yield(lock_file))
+        allow(lock_file).to(receive(:flock))
+      end
+
+      it 'returns :rotated' do
+        expect(process_credential_profile(credentials, 'dev', options)).to(eq(:rotated))
+      end
+
+      it 'cleans up the secondary key and persists a new one', :aggregate_failures do
+        process_credential_profile(credentials, 'dev', options)
+        expect(iam).to(have_received(:delete_access_key).with(hash_including(access_key_id: 'AKIASECONDARY')))
+        expect(iam).to(have_received(:create_access_key).with(hash_including(user_name: 'alice')))
+        expect(credentials).to(have_received(:save))
+      end
+
+      it 'disables then deletes the old key', :aggregate_failures do
+        process_credential_profile(credentials, 'dev', options)
+        expect(iam).to(have_received(:update_access_key).with(hash_including(access_key_id: 'AKIACURRENT', status: 'Inactive')))
+        expect(iam).to(have_received(:delete_access_key).with(hash_including(access_key_id: 'AKIACURRENT')))
+      end
+    end
+
+    context 'when disabling the old key fails after a new key was created' do
+      let(:lock_file) { instance_double(File) }
+
+      # Run the rotation and swallow the propagated error so examples can assert the rollback side effects.
+      def run_failed_rotation
+        process_credential_profile(credentials, 'dev', options)
+      rescue Aws::IAM::Errors::ServiceError
+        nil
+      end
+
+      before do
+        iam.stub_responses(:list_access_keys, { access_key_metadata: [{ access_key_id: 'AKIACURRENT', user_name: 'alice', create_date: Time.now - (100 * 24 * 60 * 60), status: 'Active' }] })
+        iam.stub_responses(:create_access_key, { access_key: { access_key_id: 'AKIANEWKEY123', secret_access_key: 'newsecret', user_name: 'alice', status: 'Active' } })
+        allow(iam).to(receive(:create_access_key).and_call_original)
+        allow(iam).to(receive(:delete_access_key).and_call_original)
+        # Fail the disable step (status Inactive) so the captured rollback lambda fires; re-activate (Active) succeeds.
+        allow(iam).to(receive(:update_access_key)) { |args| raise(Aws::IAM::Errors::ServiceError.new(nil, 'disable failed')) if args[:status] == 'Inactive' }
+        allow(credentials).to(receive(:save))
+        allow(File).to(receive(:open).with("#{Dir.home}/.aws/credentials.lock", anything, anything).and_yield(lock_file))
+        allow(lock_file).to(receive(:flock))
+      end
+
+      it 'propagates the error after rolling back' do
+        expect { process_credential_profile(credentials, 'dev', options) }
+          .to(raise_error(Aws::IAM::Errors::ServiceError))
+      end
+
+      it 'deletes the newly created key during rollback' do
+        run_failed_rotation
+        expect(iam).to(have_received(:delete_access_key).with(hash_including(access_key_id: 'AKIANEWKEY123', user_name: 'alice')))
+      end
+
+      it 're-activates the original key during rollback' do
+        run_failed_rotation
+        expect(iam).to(have_received(:update_access_key).with(hash_including(access_key_id: 'AKIACURRENT', status: 'Active')))
+      end
+
+      it 'restores the original credentials during rollback', :aggregate_failures do
+        run_failed_rotation
+        expect(cred_hash['aws_access_key_id']).to(eq('AKIACURRENT'))
+        expect(cred_hash['aws_secret_access_key']).to(eq('secret'))
+      end
+    end
   end
 
   describe '#disable_and_delete_old_key' do


### PR DESCRIPTION
## Summary

Adds the missing end-to-end coverage for the IAM key-rotation orchestration in `cycle-keys.rb`. Every helper was unit-tested in isolation, but `process_credential_profile`'s `cleanup → create → disable-and-delete` sequence and the *real* captured rollback lambda were never exercised together (those lines showed 0 hits in the coverage report). A wrong closure variable in the rollback — deleting the new key but restoring the wrong original — would have passed every existing test.

**Key changes:**

- `spec/cycle_keys_spec.rb`: add a rotation happy-path context (returns `:rotated`; cleans up the secondary key, persists a new key, then disables and deletes the old key) and a partial-failure context (when the disable step fails, the captured lambda deletes the new key, re-activates the original, and restores the original credentials).

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [x] Other (please describe): adds test coverage for the IAM key-rotation path (no production code change)

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
