### PR TITLE
Document built-in shell lint rules and disable MultilineMethodSignature cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,11 @@ Style/TopLevelMethodDefinition:
   Enabled: false
 Style/YodaExpression:
   Enabled: false
+# Autocorrect for this cop collapses multi-line method signatures and can drop
+# inline `# rubocop:disable` directives in the process. See:
+# https://docs.rubocop.org/rubocop/latest/cops_style.html#stylemultilinemethodsignature
+Style/MultilineMethodSignature:
+  Enabled: false
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 Minitest/NoTestCases:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,7 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 - File type detection based on configuration files
 - Linter installation for missing tools
 - Multi-linter execution with failure tracking
+- Built-in custom shell-script rules (`shell_lint_custom`) that run after shellcheck
 
 **Supported Linters:**
 
@@ -191,6 +192,15 @@ CI-Tools is a collection of DevOps automation tools designed to run locally or w
 - semgrep: Security scanning
 - trivy: Vulnerability, secret, and misconfiguration scanning
 - swiftlint: Swift code
+
+**Built-in Shell Rules:**
+
+Beyond shellcheck, the script applies custom shell-script rules (`shell_lint_custom`) to every `*.sh` file:
+
+- SL0001: prefer `${var}` over `$var` for variable references
+- SL0002: prefer `==` over a single `=` for string comparison inside `[ ... ]`
+
+Single-quoted spans, escaped `\$`, and comments are ignored; a `# shellcheck disable=all` directive skips the rest of that file.
 
 **Internal Dependencies:** None
 


### PR DESCRIPTION
## Summary

Follow-up documentation and lint-config changes for the built-in shell lint
rules introduced in #480. The architecture doc now describes the
`shell_lint_custom` rules, and a RuboCop cop with unsafe autocorrect behaviour
is disabled to protect inline directives.

**Key changes:**

- Document the built-in `shell_lint_custom` shell rules in `docs/architecture.md`: add a linter-features bullet and a new "Built-in Shell Rules" section covering SL0001 (`${var}` over `$var`) and SL0002 (`==` over `=` in `[ ... ]`), plus the directives that skip them.
- Disable the `Style/MultilineMethodSignature` cop in `.rubocop.yml` with an explanatory comment, since its autocorrect collapses multi-line method signatures and can drop inline `# rubocop:disable` directives.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: documentation and lint-config only change, no runtime behaviour to test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified