### PR TITLE
Guard auto-approve against self-approval; bump create-pull-request to v8

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -75,7 +75,17 @@ jobs:
     - name: Approve PR
       shell: bash
       if: steps.check.outputs.is_owner == 'true'
-      run: gh pr review --approve "$PR"
+      run: |
+        set -euo pipefail
+
+        APPROVER=$(gh api user --jq .login)
+        if [ "$APPROVER" = "$AUTHOR" ]; then
+          echo "Approver $APPROVER is the PR author; skipping self-approval."
+          exit 0
+        fi
+
+        gh pr review --approve "$PR"
       env:
         GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
+        AUTHOR: "${{github.event.pull_request.user.login}}"
         PR: "${{github.event.pull_request.number}}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -60,7 +60,7 @@ jobs:
         parameters: "--no_prompt"
         skip-checkout: 'true'
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         commit-message: Update dependencies and soup files
         branch: update-dependencies-${{github.run_id}}


### PR DESCRIPTION
## Summary

Hardens the auto-approve workflow so it never tries to approve a PR opened by
the same account that would perform the approval, and brings the dependency
update workflow's PR-creation action up to its latest major version.

GitHub rejects a review when the approver is the PR author, which would cause
the auto-approve job to fail on bot-authored PRs. The new guard compares the
authenticated approver against the PR author and exits cleanly when they match.

**Key changes:**

- `auto-approve.yml`: add a self-approval guard that looks up the authenticated
  user (`gh api user`) and skips approval when it equals the PR author, with
  `set -euo pipefail` and a new `AUTHOR` env var sourced from the PR payload.
- `dependencies.yml`: bump `peter-evans/create-pull-request` from `v7` to `v8`.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: CI workflow YAML changes; no application code to unit test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified