### PR TITLE
Fix CODEOWNERS folder exclusions and correct linters helper comment

### DIFF
--- a/generate-codeowners
+++ b/generate-codeowners
@@ -2,7 +2,20 @@
 set -euo pipefail
 
 CODEOWNERS=".github/CODEOWNERS"
-IGNORED_EXCLUDES="${GHB_IGNORED_EXCLUDES:-$(github-build --get_ignored_folders | jq -r '.ignored_folders[]' | sed 's|.*|-not -path "*/&/*"|' | tr '\n' ' ')}"
+
+# Folders to exclude from the file search, built as an array so each "-not -path …"
+# token reaches find verbatim — no word-splitting and no literal quote characters
+# (a quoted glob like "*/coverage/*" would never match). Tests can override the
+# github-build lookup via GHB_IGNORED_EXCLUDES (a space-separated find expression).
+if [ -n "${GHB_IGNORED_EXCLUDES:-}" ]; then
+  read -ra IGNORED_EXCLUDES <<< "${GHB_IGNORED_EXCLUDES}"
+else
+  IGNORED_EXCLUDES=()
+
+  while IFS= read -r folder; do
+    [ -n "${folder}" ] && IGNORED_EXCLUDES+=(-not -path "*/${folder}/*")
+  done < <(github-build --get_ignored_folders | jq -r '.ignored_folders[]')
+fi
 
 function check_file()
 {
@@ -16,8 +29,7 @@ function check_file()
     exit 1
   fi
 
-  # shellcheck disable=SC2086
-  if find . -name "${1}" -not -path "./*-scripts/*" -not -path "./codedeploy/*" -not -path "./bin/*" -not -path "./sbin/*" ${IGNORED_EXCLUDES} | grep -E '.*' &> /dev/null; then
+  if find . -name "${1}" -not -path "./*-scripts/*" -not -path "./codedeploy/*" -not -path "./bin/*" -not -path "./sbin/*" "${IGNORED_EXCLUDES[@]}" | grep -E '.*' &> /dev/null; then
     printf "%-24s %s\n" "${1}" "${2}" >> "./${CODEOWNERS}"
   fi
 }

--- a/linters
+++ b/linters
@@ -10,7 +10,7 @@ is_darwin() {
 }
 
 # Emits "sudo" or "" depending on whether the named command's path is user-writable.
-# Usage: ${SUDO_FOR_NPM} npm install -g foo
+# Usage: $(sudo_for_user_command npm) npm install -g foo
 sudo_for_user_command() {
   if command -v "${1}" | grep "${HOME}" &>/dev/null; then
     echo ""

--- a/tests/generate_codeowners.bats
+++ b/tests/generate_codeowners.bats
@@ -2,7 +2,7 @@
 
 setup() {
   export PATH="${BATS_TEST_DIRNAME}/../:${PATH}"
-  export GHB_IGNORED_EXCLUDES="-not -path '*/node_modules/*' -not -path '*/vendor/*' -not -path '*/.build/*' -not -path '*/Pods/*' -not -path '*/Carthage/*' -not -path '*/DerivedData/*'"
+  export GHB_IGNORED_EXCLUDES="-not -path */node_modules/* -not -path */vendor/* -not -path */.build/* -not -path */Pods/* -not -path */Carthage/* -not -path */DerivedData/*"
   TEST_DIR=$(mktemp -d)
   cd "${TEST_DIR}"
 }
@@ -48,6 +48,21 @@ teardown() {
   mkdir -p .github
   generate-codeowners "@build-team" "@default-team"
   ! grep -q ".golangci.yml" .github/CODEOWNERS
+}
+
+@test "includes shell files outside ignored folders" {
+  mkdir -p .github
+  touch script.sh
+  generate-codeowners "@build-team" "@default-team"
+  grep -qE '^\*\.sh' .github/CODEOWNERS
+}
+
+@test "excludes files located only inside ignored folders" {
+  mkdir -p .github node_modules
+  touch node_modules/dep.sh
+  generate-codeowners "@build-team" "@default-team"
+  # The only *.sh file lives in an ignored folder, so no *.sh ownership line should appear.
+  ! grep -qE '^\*\.sh' .github/CODEOWNERS
 }
 
 @test "preserves custom lines between markers" {


### PR DESCRIPTION
## Summary

Two low-severity fixes surfaced by a code review of the CI tools.

`generate-codeowners` built its dynamic ignore-folder exclusions with
`sed 's|.*|-not -path "*/&/*"|'`, which embeds **literal double-quote characters**
into each glob. Word-split unquoted into `find` (with `# shellcheck disable=SC2086`),
the resulting `-path` patterns looked like `"*/coverage/*"` and could never match a
real path, so folders reported by `github-build --get_ignored_folders` were still
scanned. The exclusions are now built as a bash array and expanded with
`"${IGNORED_EXCLUDES[@]}"`, which passes each token to `find` verbatim and removes the
need for the `SC2086` suppression. A regression test was added that creates a `.sh`
file inside an ignored folder and asserts no `*.sh` ownership line is emitted (this
test fails against the old code and passes against the new code).

The `linters` `sudo_for_user_command` helper carried a usage comment referencing a
non-existent `${SUDO_FOR_NPM}` variable; it now shows the real call form
`$(sudo_for_user_command npm) npm install -g foo`.

**Key changes:**

- `generate-codeowners`: build ignore-folder exclusions as an array; drop the buggy
  literal-quoted `sed` and the `SC2086` disable.
- `tests/generate_codeowners.bats`: clean the `GHB_IGNORED_EXCLUDES` override value and
  add include/exclude regression tests for shell files in ignored folders.
- `linters`: correct the `sudo_for_user_command` usage comment.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified