### PR TITLE
Fix RUBY_BUNDLER_CACHE workflow env var silently disabling bundler cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
   pull-requests: read
 env:
-  RUBY-BUNDLER-CACHE: 'true'
+  RUBY_BUNDLER_CACHE: 'true'
 concurrency:
   group: build-${{github.ref}}
   cancel-in-progress: true
@@ -223,7 +223,7 @@ jobs:
       uses: cloud-officer/ci-actions/setup@v2
       if: "${{needs.variables.outputs.SKIP_LICENSES != '1' || needs.variables.outputs.SKIP_TESTS != '1'}}"
       with:
-        ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
+        ruby-bundler-cache: "${{env.RUBY_BUNDLER_CACHE}}"
         ssh-key: "${{secrets.SSH_KEY}}"
         aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
         aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
   pull-requests: read
 env:
-  RUBY-BUNDLER-CACHE: 'true'
+  RUBY_BUNDLER_CACHE: 'true'
 jobs:
   update_dependencies:
     name: Update Dependencies
@@ -23,7 +23,7 @@ jobs:
       with:
         ssh-key: "${{secrets.SSH_KEY}}"
         github-token: "${{secrets.GH_PAT}}"
-        ruby-bundler-cache: "${{env.RUBY-BUNDLER-CACHE}}"
+        ruby-bundler-cache: "${{env.RUBY_BUNDLER_CACHE}}"
         aws-access-key-id: "${{secrets.AWS_ACCESS_KEY_ID}}"
         aws-secret-access-key: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
         aws-region: "${{secrets.AWS_DEFAULT_REGION}}"


### PR DESCRIPTION
## Summary

The build and cron-dependencies workflows defined a `RUBY-BUNDLER-CACHE` env var and
read it as `${{ env.RUBY-BUNDLER-CACHE }}`. In GitHub Actions expression syntax,
hyphens are the subtraction operator, so `env.RUBY-BUNDLER-CACHE` parses as
`env.RUBY - BUNDLER - CACHE` (all undefined, coerced to 0) instead of the string
`'true'`. The `cloud-officer/ci-actions/setup@v2` step therefore received a falsy
value and bundler caching was silently disabled on every build and weekly dependency
run. The expression never errored, so the bug was invisible.

This renames the variable to a valid identifier (`RUBY_BUNDLER_CACHE`) and reads it
with dot notation, so the intended `'true'` actually reaches the action. The rename
(rather than bracket notation `env['RUBY-BUNDLER-CACHE']`) also removes the hyphen
footgun for future readers. Verified with actionlint.

**Key changes:**

- `.github/workflows/build.yml`: rename the env var and its reference to
  `RUBY_BUNDLER_CACHE`.
- `.github/workflows/dependencies.yml`: same rename and reference fix.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: workflow-only change; validated with actionlint (no unit-test harness for CI YAML)
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified