### PR TITLE
Add Windows ssm-jump installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
-# Edit at https://www.toptal.com/developers/gitignore?templates=batch,eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,rubymine,sublimetext,vim,visualstudiocode,windows
-
-### Batch ###
-# BatchFiles
-*.bat
-*.cmd
-*.btm
+# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,rubymine,sublimetext,vim,visualstudiocode,windows
 
 ### Eclipse ###
 .metadata
@@ -520,7 +514,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/batch,eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,rubymine,sublimetext,vim,visualstudiocode,windows
+# End of https://www.toptal.com/developers/gitignore/api/eclipse,emacs,jetbrains,linux,macos,netbeans,nova,ruby,rubymine,sublimetext,vim,visualstudiocode,windows
 
 # BEGIN AI Assistants
 

--- a/ssm-jump.install.bat
+++ b/ssm-jump.install.bat
@@ -1,0 +1,58 @@
+@ECHO OFF
+
+SET /P AWS_PROFILE=Enter AWS CLI profile name:
+SET /P AWS_INSTANCE=Enter EC2 instance name (e.g. api-prod-standalone):
+SET /P FORWARD_HOST=Enter forward host (e.g. db-slave.example.com:3306:3306):
+SET /P SSM_DOCUMENT=Enter SSM document name (default: AWS-StartPortForwardingSessionToRemoteHost):
+SET /P SHORTCUT_NAME=Enter desktop shortcut name (e.g. my-project-prod):
+
+IF "%SSM_DOCUMENT%"=="" SET SSM_DOCUMENT=AWS-StartPortForwardingSessionToRemoteHost
+
+ECHO Install AWS CLI and session manager
+winget install --exact --id Amazon.AWSCLI --accept-package-agreements --accept-source-agreements
+winget install --exact --id Amazon.SessionManagerPlugin
+
+ECHO Install git, mainly because bash and other GNU tools are well packaged
+winget install --exact --id Git.Git
+
+ECHO Ensure AWS CLI is available in PATH
+SET PATH=%PATH%;C:\Program Files\Amazon\AWSCLIV2
+
+ECHO Check AWS authentication
+aws --profile %AWS_PROFILE% sts get-caller-identity && (
+	ECHO .
+	ECHO AWS authentication successful
+	ECHO .
+) || (
+	ECHO .
+	ECHO Missing AWS credentials, triggering configuration
+	ECHO .
+
+	aws --profile %AWS_PROFILE% configure
+
+	aws --profile %AWS_PROFILE% sts get-caller-identity || (
+		ECHO .
+		ECHO Failed to authenticate against AWS. Exiting.
+		ECHO .
+		PAUSE
+		EXIT /B 1
+	)
+)
+
+ECHO Install SSM jump script
+IF NOT EXIST "%USERPROFILE%\.ssm-jump" MKDIR "%USERPROFILE%\.ssm-jump"
+CD "%USERPROFILE%\.ssm-jump"
+curl.exe -SL --fail --progress-bar https://raw.githubusercontent.com/Cloud-Officer/ci-tools/refs/heads/master/ssm-jump --output ssm-jump.sh || (
+	ECHO .
+	ECHO Failed to download ssm-jump script from GitHub. Exiting.
+	ECHO .
+	PAUSE
+	EXIT /B 1
+)
+
+ECHO Generate connect helper on desktop
+SET CMD_COMMON="C:\Program Files\Git\bin\bash.exe" "%USERPROFILE%\.ssm-jump\ssm-jump.sh" --profile %AWS_PROFILE% --document %SSM_DOCUMENT%
+CD "%USERPROFILE%\Desktop"
+IF NOT EXIST %SHORTCUT_NAME%.bat ECHO %CMD_COMMON% %AWS_INSTANCE% --forward %FORWARD_HOST% >%SHORTCUT_NAME%.bat
+
+PAUSE


### PR DESCRIPTION
## Summary

Adds a Windows batch installer (`ssm-jump.install.bat`) that bootstraps everything a Windows user needs to connect through `ssm-jump`: it installs the AWS CLI, the Session Manager plugin, and Git via `winget`, verifies (and configures, if needed) AWS authentication, downloads the latest `ssm-jump` script from this repo, and generates a ready-to-run desktop shortcut for a given instance and forward host.

Because the previous `.gitignore` ignored all batch files (`*.bat`, `*.cmd`, `*.btm`), the new installer could not be committed. The batch section is removed from `.gitignore` so the installer can be tracked.

**Key changes:**

- Add `ssm-jump.install.bat`, an interactive Windows installer that prompts for AWS profile, instance, forward host, SSM document, and shortcut name, installs prerequisites via `winget`, validates AWS credentials, fetches the `ssm-jump` script, and writes a desktop connect shortcut.
- Remove the Batch template (`*.bat`, `*.cmd`, `*.btm`) from `.gitignore` and update the toptal gitignore header/footer accordingly so `.bat` files are no longer ignored.

## Types of changes

- [ ] Bugfix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: The change is a Windows-only batch installer and a `.gitignore` edit; there is no test harness for batch scripts and no Ruby code is affected.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified