### PR TITLE
Fix #493: Lambda function name built with spaces — publish path can never succeed

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -90,7 +90,7 @@ end
 def publish_lambda_and_update_cloudfront(options)
   puts("Publishing lambda version for function #{options[:lambda_publish_version]}...")
   lambda_client = Aws::Lambda::Client.new
-  version = lambda_client.publish_version({ function_name: "#{options[:environment]} - #{options[:lambda_publish_version]}" })
+  version = lambda_client.publish_version({ function_name: "#{options[:environment]}-#{options[:lambda_publish_version]}" })
   puts("Publish completed successfully for function ARN = #{version.function_arn}.")
   puts('Checking cloudfront distributions...')
   cloudfront = Aws::CloudFront::Client.new

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -833,6 +833,12 @@ RSpec.describe(Deploy) do
         run_deployment({ environment: 'beta', instance: 'api', profile: 'dev', lambda_publish_version: 'my-function' })
         expect(lambda_client).to(have_received(:publish_version))
       end
+
+      it 'builds a function_name without spaces so AWS accepts it', :aggregate_failures do
+        run_deployment({ environment: 'beta', instance: 'api', profile: 'dev', lambda_publish_version: 'my-function' })
+        expect(lambda_client).to(have_received(:publish_version).with(hash_including(function_name: 'beta-my-function')))
+        expect(lambda_client).not_to(have_received(:publish_version).with(hash_including(function_name: a_string_matching(/\s/))))
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

`publish_lambda_and_update_cloudfront` built the Lambda function name as
`"#{environment} - #{version}"` with literal spaces around the dash
(`deploy.rb:93`). AWS Lambda function names must match `[a-zA-Z0-9-_]+`, so
`publish_version` was rejected server-side with a `ValidationException` on
every call — the `--lambda_publish_version` path could never succeed against
real AWS. The existing spec only asserted that `publish_version` was *called*
(against a stub), so it never caught the malformed name.

**Key changes:**

- `deploy.rb`: remove the spaces around the separator so the name is built as `"#{environment}-#{version}"`.
- `spec/deploy_spec.rb`: add a regression spec asserting the exact `function_name` sent to the stubbed client (`beta-my-function`) and that it contains no whitespace. Confirmed it fails before the fix and passes after.

Fixes #493

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified