### PR TITLE
Fix #494: golangci-lint installed from v1 module path — Linux pinned to v1.64.8

### DIFF
--- a/linters
+++ b/linters
@@ -222,7 +222,7 @@ if [ -f .golangci.yml ]; then
     if is_darwin; then
       brew install golangci-lint
     else
-      go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
       export PATH="${PATH}:${HOME}/go/bin"
     fi
   fi

--- a/tests/linters.bats
+++ b/tests/linters.bats
@@ -85,6 +85,43 @@ stub_all_linters() {
   [[ "$output" == *"Checking YAML"* ]]
 }
 
+@test "installs golangci-lint from the v2 module path on Linux" {
+  skip_unless_globstar
+  touch .golangci.yml
+
+  # Isolate HOME so the install branch writes into the temp dir, and trim PATH
+  # to system dirs so a host-installed golangci-lint can't satisfy `command -v`
+  # and skip the auto-install branch we want to exercise. Keep a modern bash
+  # (linters needs globstar, absent from macOS /bin/bash 3.2) by symlinking the
+  # current interpreter into a private bin dir that holds no golangci-lint.
+  export HOME="${TEST_DIR}/home"
+  mkdir -p "${HOME}/go/bin" "${HOME}/bin"
+  ln -s "$(command -v bash)" "${HOME}/bin/bash"
+  export PATH="${BATS_TEST_DIRNAME}/../:${HOME}/bin:/usr/bin:/bin"
+
+  # Force the non-Darwin (Linux) install branch.
+  function uname() { echo "Linux"; }
+  export -f uname
+
+  # Capture the module path `go install` is asked to fetch, and drop a runnable
+  # golangci-lint into HOME/go/bin so the subsequent `golangci-lint run` succeeds.
+  function go() {
+    echo "go invoked: $*"
+    cat > "${HOME}/go/bin/golangci-lint" <<'EOF'
+#!/usr/bin/env bash
+echo "golangci-lint invoked: $*"
+EOF
+    chmod +x "${HOME}/go/bin/golangci-lint"
+  }
+  export -f go
+
+  run linters
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Checking Go..."* ]]
+  [[ "$output" == *"github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"* ]]
+  [[ "$output" == *"golangci-lint invoked: run"* ]]
+}
+
 @test "runs rubocop when its config is present" {
   skip_unless_globstar
   touch .rubocop.yml


### PR DESCRIPTION
## Summary

On Linux, `linters` auto-installed golangci-lint via
`go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
(`linters:225`). Since golangci-lint v2 the module path moved to
`.../v2/...`, so `@latest` on the v1 path resolves only to the final v1
release (v1.64.8), while the macOS branch (`brew install golangci-lint`)
installs v2.x. Linux was silently pinned to a 15-month-old major version,
and repos with a v2-format `.golangci.yml` failed on Linux. This restores
the repo's floating-latest convention so both platforms track the latest
major.

**Key changes:**

- `linters`: install golangci-lint from the v2 module path (`github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`).
- `tests/linters.bats`: add a regression test that exercises the non-Darwin (Linux) auto-install branch, captures the module path passed to `go install`, and asserts it is the v2 path. The bug went undetected because the existing suite stubs golangci-lint and never reached the install branch.

Fixes #494

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified