### PR TITLE
Fix #495: update_ssm_parameters runs outside the SSM rollback scope

### DIFF
--- a/deploy.rb
+++ b/deploy.rb
@@ -258,6 +258,14 @@ def update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
   puts("Update completed successfully for cloudformation stack #{stack_name} with #{prefix}ImageId #{ami_id}.")
 end
 
+def update_ssm_parameters_with_rollback(parameters, prefix, ami_id, asg, options, ssm_prefix, ssm_snapshot)
+  update_ssm_parameters(parameters, prefix, ami_id, asg, options, ssm_prefix)
+rescue StandardError
+  puts('SSM parameter update failed, rolling back SSM parameters...')
+  restore_ssm_parameters(ssm_snapshot)
+  raise
+end
+
 def update_stack_with_ssm_rollback(cfn, stack_name, parameters, prefix, ami_id, ssm_snapshot)
   update_cloudformation_stack(cfn, stack_name, parameters, prefix, ami_id)
 rescue SystemExit => e
@@ -430,7 +438,7 @@ def run_deployment(options)
   ctx = discover_cfn_stack_context(cfn, options)
 
   ssm_snapshot = capture_ssm_snapshot(ctx[:parameters], ctx[:prefix], ami_id, asg, options, ctx[:ssm_prefix])
-  update_ssm_parameters(ctx[:parameters], ctx[:prefix], ami_id, asg, options, ctx[:ssm_prefix])
+  update_ssm_parameters_with_rollback(ctx[:parameters], ctx[:prefix], ami_id, asg, options, ctx[:ssm_prefix], ssm_snapshot)
   mark_cfn_secrets_for_previous_value!(ctx[:parameters])
 
   update_stack_with_ssm_rollback(cfn, ctx[:stack_name], ctx[:parameters], ctx[:prefix], ami_id, ssm_snapshot)

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -840,6 +840,41 @@ RSpec.describe(Deploy) do
         expect(lambda_client).not_to(have_received(:publish_version).with(hash_including(function_name: a_string_matching(/\s/))))
       end
     end
+
+    context 'with the standard ASG/CFN deploy path' do
+      let(:ctx) do
+        { stack_name: 'beta1-StackInstances-x', parameters: [], environment: 'beta', subnet: 1, prefix: 'API', ssm_prefix: '/beta/1' }
+      end
+      let(:snapshot) { { snapshot_name => 'ami-old' } }
+      let(:snapshot_name) { '/beta/1/APIImageId' }
+
+      before do
+        allow(Aws::AutoScaling::Resource).to(receive(:new).and_return(instance_double(Aws::AutoScaling::Resource, client: nil)))
+        allow(Aws::CloudFormation::Client).to(receive(:new).and_return(instance_double(Aws::CloudFormation::Client)))
+        allow(self).to(
+          receive_messages(
+            resolve_ami_id: 'ami-new',
+            resolve_capacity_factors: { asg_increase: 1, asg_multiplier: 2 },
+            find_auto_scaling_group: { name: 'asg', min_size: 1, max_size: 4, desired_capacity: 2 },
+            discover_load_balancer: [nil, nil],
+            discover_cfn_stack_context: ctx,
+            capture_ssm_snapshot: snapshot,
+            fetch_asg_mixed_parameters: { base_capacity: 0, percent_above: 100 },
+            compute_asg_capacity_plan: { new_capacity: 4, new_max: 8 }
+          )
+        )
+        allow(self).to(receive(:mark_cfn_secrets_for_previous_value!))
+        allow(self).to(receive(:update_stack_with_ssm_rollback))
+        allow(self).to(receive(:update_asg_capacity))
+        allow(self).to(receive(:run_rolling_deploy))
+        allow(self).to(receive(:update_ssm_parameters_with_rollback))
+      end
+
+      it 'routes the SSM parameter update through the rollback-protected path with the snapshot' do
+        run_deployment({ environment: 'beta', instance: 'api', profile: nil })
+        expect(self).to(have_received(:update_ssm_parameters_with_rollback).with([], 'API', 'ami-new', anything, anything, '/beta/1', snapshot))
+      end
+    end
   end
 
   describe '#update_stack_with_ssm_rollback' do
@@ -903,6 +938,57 @@ RSpec.describe(Deploy) do
         expect { update_stack_with_ssm_rollback(cfn, 'test-stack', [], 'API', 'ami-123', {}) }
           .to(raise_error(StandardError, 'boom'))
         expect(ssm).not_to(have_received(:put_parameter))
+      end
+    end
+  end
+
+  describe '#update_ssm_parameters_with_rollback' do
+    let(:ssm)          { Aws::SSM::Client.new(stub_responses: true) }
+    let(:param_name)   { '/beta/1/APIImageId'                                                                }
+    let(:ssm_snapshot) { { param_name => 'ami-old' }                                                         }
+    let(:parameter)    { instance_double(Aws::CloudFormation::Types::Parameter, parameter_key: 'APIImageId') }
+    let(:asg)          { { min_size: 1, max_size: 4, desired_capacity: 2 }                                   }
+
+    # asg/options are irrelevant for the APIImageId path (resolve_parameter_value returns ami_id),
+    # so options is passed inline rather than memoized to keep the helper count within RuboCop limits.
+    before { allow(Aws::SSM::Client).to(receive(:new).and_return(ssm)) }
+
+    context 'when the parameter writes succeed' do
+      before { allow(ssm).to(receive(:put_parameter).and_call_original) }
+
+      it 'writes the new values and does NOT restore the snapshot', :aggregate_failures do
+        update_ssm_parameters_with_rollback([parameter], 'API', 'ami-new', asg, { type: 't3.micro' }, '/beta/1', ssm_snapshot)
+        expect(ssm).to(have_received(:put_parameter).with(hash_including(name: param_name, value: 'ami-new')))
+        expect(ssm).not_to(have_received(:put_parameter).with(hash_including(value: 'ami-old')))
+      end
+    end
+
+    context 'when put_parameter fails mid-loop' do
+      # Fail the new-value write (the update), but let the snapshot restore succeed.
+      before do
+        allow(ssm).to(receive(:put_parameter)) do |args|
+          raise(Aws::SSM::Errors::ThrottlingException.new(nil, 'throttled')) if args[:value] == 'ami-new'
+        end
+      end
+
+      it 'restores the snapshot and re-raises', :aggregate_failures do
+        expect { update_ssm_parameters_with_rollback([parameter], 'API', 'ami-new', asg, { type: 't3.micro' }, '/beta/1', ssm_snapshot) }
+          .to(raise_error(Aws::SSM::Errors::ThrottlingException))
+        expect(ssm).to(have_received(:put_parameter).with(hash_including(name: param_name, value: 'ami-old')))
+      end
+    end
+
+    context 'with an empty snapshot' do
+      before do
+        allow(ssm).to(receive(:put_parameter)) do |args|
+          raise(Aws::SSM::Errors::ThrottlingException.new(nil, 'throttled')) if args[:value] == 'ami-new'
+        end
+      end
+
+      it 're-raises but performs no restore writes', :aggregate_failures do
+        expect { update_ssm_parameters_with_rollback([parameter], 'API', 'ami-new', asg, { type: 't3.micro' }, '/beta/1', {}) }
+          .to(raise_error(Aws::SSM::Errors::ThrottlingException))
+        expect(ssm).not_to(have_received(:put_parameter).with(hash_including(value: 'ami-old')))
       end
     end
   end


### PR DESCRIPTION
## Summary

In `run_deployment`, `update_ssm_parameters` (`deploy.rb:433`) ran OUTSIDE the
SSM-rollback scope — only the CloudFormation update was protected by
`update_stack_with_ssm_rollback`/`restore_ssm_parameters`. The parameter writes
happen one-by-one with no rescue, so a mid-loop `put_parameter` failure
(throttling, permissions) left SSM half-updated (e.g. new ImageId but old
MinSize) with no restore — even though the snapshot needed to restore it was
captured one line above. This wraps the parameter write in the same rollback
machinery so a failure restores the snapshot, exactly like a CloudFormation
failure does. Residual gap from the rollback work in #387 (#462/#463).

**Key changes:**

- `deploy.rb`: add `update_ssm_parameters_with_rollback`, a thin wrapper that runs `update_ssm_parameters` and, on any `StandardError`, restores the SSM snapshot and re-raises (mirrors the existing `update_stack_with_ssm_rollback`). `run_deployment` now routes the parameter update through it, passing the snapshot.
- `spec/deploy_spec.rb`: add a `#update_ssm_parameters_with_rollback` describe (success → no restore; mid-loop failure → snapshot restored and re-raised; empty snapshot → re-raises with no restore writes), plus a `#run_deployment` wiring spec asserting the deploy path routes the SSM update through the rollback-protected wrapper (pins the call site so a future revert is caught).

Fixes #495

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified