### PR TITLE
Fix #501: install cfn-lint and semgrep via pipx (PEP 668 safe)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN \
 		libtool \
 		libtool-bin \
 		make \
+		pipx \
 		pkg-config \
-		python3-pip \
 		ruby \
 		ruby-all-dev \
 		ruby-build \

--- a/linters
+++ b/linters
@@ -19,6 +19,21 @@ sudo_for_user_command() {
   fi
 }
 
+# Installs a Python CLI tool in its own isolated environment via pipx, on Linux.
+# pipx is used instead of a bare `pip3 install` because Debian 12+/Ubuntu 23.04+
+# mark the system Python externally managed (PEP 668), so pip3 refuses to install
+# into it. pipx is bootstrapped through apt when absent (mirroring how the npm
+# branch installs npm), and its bin dir is added to PATH (like the go branches).
+# Usage: pipx_install cfn-lint
+pipx_install() {
+  if ! command -v pipx &>/dev/null; then
+    sudo apt-get --yes install --no-install-recommends pipx
+  fi
+
+  pipx install "${1}"
+  export PATH="${PATH}:${HOME}/.local/bin"
+}
+
 # Common find filter used for files-to-lint discovery. Pass the -name pattern as $1.
 find_lintable() {
   find . -name "${1}" \
@@ -208,7 +223,7 @@ if [ -f .cfnlintrc ]; then
     if is_darwin; then
       brew install cfn-lint
     else
-      pip3 install cfn-lint
+      pipx_install cfn-lint
     fi
   fi
 
@@ -354,7 +369,7 @@ if [ -f .semgrepignore ]; then
     if is_darwin; then
       brew install semgrep
     else
-      pip3 install semgrep
+      pipx_install semgrep
     fi
   fi
 

--- a/tests/dockerfile.bats
+++ b/tests/dockerfile.bats
@@ -11,8 +11,8 @@ setup() {
   grep -qE '^[[:space:]]*jq[[:space:]]*\\?$' "${DOCKERFILE}"
 }
 
-@test "installs python3-pip (required by linters cfn-lint/semgrep self-install)" {
-  grep -qE '^[[:space:]]*python3-pip[[:space:]]*\\?$' "${DOCKERFILE}"
+@test "installs pipx (required by linters cfn-lint/semgrep self-install)" {
+  grep -qE '^[[:space:]]*pipx[[:space:]]*\\?$' "${DOCKERFILE}"
 }
 
 @test "installs golang (required by linters actionlint/golangci-lint/protolint self-install)" {

--- a/tests/linters.bats
+++ b/tests/linters.bats
@@ -122,6 +122,72 @@ EOF
   [[ "$output" == *"golangci-lint invoked: run"* ]]
 }
 
+@test "installs cfn-lint via pipx (not bare pip3) on Linux" {
+  skip_unless_globstar
+  touch .cfnlintrc
+
+  # Isolate HOME and trim PATH (same rationale as the golangci-lint test) so the
+  # auto-install branch runs and a host-installed cfn-lint/pipx can't short-circuit it.
+  export HOME="${TEST_DIR}/home"
+  mkdir -p "${HOME}/.local/bin" "${HOME}/bin"
+  ln -s "$(command -v bash)" "${HOME}/bin/bash"
+  export PATH="${BATS_TEST_DIRNAME}/../:${HOME}/bin:/usr/bin:/bin"
+
+  # Force the non-Darwin (Linux) install branch.
+  function uname() { echo "Linux"; }
+  export -f uname
+
+  # Stub pipx: record the install request and drop a runnable cfn-lint into the
+  # pipx bin dir so the subsequent `cfn-lint ...` call succeeds. Its presence as
+  # a function also satisfies `command -v pipx`, so the apt bootstrap is skipped.
+  function pipx() {
+    echo "pipx invoked: $*"
+    cat > "${HOME}/.local/bin/cfn-lint" <<'EOF'
+#!/usr/bin/env bash
+echo "cfn-lint invoked: $*"
+EOF
+    chmod +x "${HOME}/.local/bin/cfn-lint"
+  }
+  export -f pipx
+
+  run linters
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Checking CloudFormation templates..."* ]]
+  [[ "$output" == *"pipx invoked: install cfn-lint"* ]]
+  [[ "$output" == *"cfn-lint invoked: --non-zero-exit-code error"* ]]
+  [[ "$output" != *"pip3 install"* ]]
+}
+
+@test "installs semgrep via pipx (not bare pip3) on Linux" {
+  skip_unless_globstar
+  touch .semgrepignore
+
+  export HOME="${TEST_DIR}/home"
+  mkdir -p "${HOME}/.local/bin" "${HOME}/bin"
+  ln -s "$(command -v bash)" "${HOME}/bin/bash"
+  export PATH="${BATS_TEST_DIRNAME}/../:${HOME}/bin:/usr/bin:/bin"
+
+  function uname() { echo "Linux"; }
+  export -f uname
+
+  function pipx() {
+    echo "pipx invoked: $*"
+    cat > "${HOME}/.local/bin/semgrep" <<'EOF'
+#!/usr/bin/env bash
+echo "semgrep invoked: $*"
+EOF
+    chmod +x "${HOME}/.local/bin/semgrep"
+  }
+  export -f pipx
+
+  run linters
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Checking with semgrep..."* ]]
+  [[ "$output" == *"pipx invoked: install semgrep"* ]]
+  [[ "$output" == *"semgrep invoked: scan"* ]]
+  [[ "$output" != *"pip3 install"* ]]
+}
+
 @test "runs rubocop when its config is present" {
   skip_unless_globstar
   touch .rubocop.yml


### PR DESCRIPTION
## Summary

On modern Debian-family Linux (Debian 12+ / Ubuntu 23.04+, including the `ubuntu-latest` CI runners and the project's own image), PEP 668 marks the system Python externally managed, so a bare `pip3 install` refuses with `externally-managed-environment`. The `linters` script installed **cfn-lint** and **semgrep** that way, breaking both lint branches on every modern Linux host. This switches them to `pipx`, the supported way to install Python CLI apps on such systems.

**Key changes:**

- `linters`: added a `pipx_install` helper that bootstraps `pipx` via apt when absent (mirroring how the eslint branch installs npm) and adds `~/.local/bin` to `PATH` (like the go branches export `~/go/bin`); cfn-lint and semgrep now call `pipx_install` instead of bare `pip3 install`. `bandit`/`flake8` were already apt-based and are unaffected.
- `Dockerfile`: `python3-pip` -> `pipx`. The just-merged #500 added `python3-pip` specifically for these self-install branches; they now use `pipx` (which pulls pip3 in transitively), so `pipx` is the accurate dependency to ship in the image.
- `tests/dockerfile.bats`: updated the now-stale "installs python3-pip" assertion to assert `pipx`.
- `tests/linters.bats`: added two Linux self-install regression tests (cfn-lint and semgrep via pipx), modeled on the existing golangci-lint test. They fail against the pre-fix `pip3` code and pass after the fix.

Tests: `bats tests/` 47 tests, 0 failures; `shellcheck` clean on `linters`; `hadolint` clean on `Dockerfile`.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

Fixes #501