### PR TITLE
Fix #505-509: standardize CLI help/exit, banner, .bat quoting, docs

### DIFF
--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -207,10 +207,6 @@ def parse_cycle_keys_options(argv = ARGV)
     opts.on('--profile profile', String)
     opts.on('--username username', String)
     opts.on('--force')
-    opts.on('-h', '--help') do
-      puts(opts)
-      exit(1)
-    end
   end
 end
 

--- a/cycle-keys.rb
+++ b/cycle-keys.rb
@@ -107,7 +107,7 @@ def rollback_key_change(iam, credentials, profile, user_name, credentials_file_n
   end
 end
 
-KEY_AGE_DAYS_THRESHOLD = 80 # AWS rotates at 90; this provides a 10-day buffer for cron schedules.
+KEY_AGE_DAYS_THRESHOLD = 80 # Compliance policy requires rotation every 90 days (CIS / access-keys-rotated rule); rotate at 80 to leave a 10-day buffer for cron schedules.
 
 def build_iam_client(region, access_key, secret_key)
   Aws::IAM::Client.new(

--- a/deploy.rb
+++ b/deploy.rb
@@ -476,10 +476,6 @@ def parse_deploy_options(argv = ARGV)
     opts.on('--preserve_desired_capacity')
     opts.on('--skip_scale_down')
     opts.on('--spot_target_capacity spot_target_capacity', Integer)
-    opts.on('-h', '--help') do
-      puts(opts)
-      exit(0)
-    end
   end
 end
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -228,6 +228,30 @@ Single-quoted spans, escaped `\$`, and comments are ignored; a `# shellcheck dis
 
 **External Dependencies:** AWS CLI, jq
 
+### ssm-jump.install.bat
+
+**Purpose:** Windows installer that provisions the prerequisites for `ssm-jump` and generates a desktop connection shortcut.
+
+**Location:** `ssm-jump.install.bat`
+
+**Key Components:**
+
+- Interactive prompts for AWS profile, instance name, forward host, SSM document, and shortcut name
+- Prerequisite installation via `winget`
+- AWS authentication check with fallback to `aws configure`
+- Desktop shortcut (`.bat`) generation that invokes `ssm-jump` through Git-for-Windows bash
+
+**Functionality:**
+
+- Installs the AWS CLI, Session Manager plugin, and Git for Windows using `winget`
+- Verifies AWS credentials with `sts get-caller-identity`, running `aws configure` and re-checking if authentication fails
+- Downloads the `ssm-jump` script from GitHub into `%USERPROFILE%\.ssm-jump`
+- Writes a per-instance launcher shortcut on the Desktop that runs `ssm-jump` via `bash.exe` with the chosen profile, document, instance, and forward host
+
+**Internal Dependencies:** None
+
+**External Dependencies:** winget, Git-for-Windows bash, AWS CLI, Session Manager plugin, curl
+
 ### sync-jira-release
 
 **Purpose:** Synchronizes Jira releases with GitHub pull requests by extracting issue keys from PRs.

--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -64,7 +64,7 @@ def process_log_group(logs, log_group, keys, retention_in_days)
 end
 
 def parse_encrypt_logs_options(argv = ARGV)
-  CliMain.parse_options!(banner: 'Usage: encrypt_logs.rb options', mandatory: %i[profile retention_in_days], argv: argv) do |opts|
+  CliMain.parse_options!(banner: "Usage: #{File.basename($PROGRAM_NAME)} options", mandatory: %i[profile retention_in_days], argv: argv) do |opts|
     opts.on('--profile profile', String)
     opts.on('--retention_in_days retention_in_days', Integer)
     opts.on('-h', '--help') do

--- a/encrypt-logs.rb
+++ b/encrypt-logs.rb
@@ -67,10 +67,6 @@ def parse_encrypt_logs_options(argv = ARGV)
   CliMain.parse_options!(banner: 'Usage: encrypt_logs.rb options', mandatory: %i[profile retention_in_days], argv: argv) do |opts|
     opts.on('--profile profile', String)
     opts.on('--retention_in_days retention_in_days', Integer)
-    opts.on('-h', '--help') do
-      puts(opts)
-      exit(1)
-    end
   end
 end
 

--- a/lib/cli_main.rb
+++ b/lib/cli_main.rb
@@ -29,6 +29,13 @@ module CliMain
       opts.separator('')
       opts.separator('options')
       yield(opts)
+      # Provide a uniform -h/--help handler for every CLI so they all print
+      # usage and exit 0 (an explicitly requested help is a success, not an
+      # error). Tools must not redefine -h/--help themselves.
+      opts.on('-h', '--help', 'Print this help message') do
+        puts(opts)
+        exit(0)
+      end
     end.parse!(argv, into: options)
 
     missing = mandatory.select { |param| options[param].nil? }

--- a/spec/cli_main_spec.rb
+++ b/spec/cli_main_spec.rb
@@ -58,5 +58,24 @@ RSpec.describe(CliMain) do
       end
       expect(argv).to(eq(%w[unconsumed]))
     end
+
+    def expect_help_exit(flag)
+      expect { parse_with_help(flag) }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+    end
+
+    def parse_with_help(flag)
+      described_class.parse_options!(banner: 'Usage: x', mandatory: %i[name], argv: [flag]) do |opts|
+        opts.on('--name name', String)
+      end
+    end
+
+    %w[-h --help].each do |flag|
+      it "prints usage and exits 0 for #{flag}", :aggregate_failures do
+        expect do
+          expect_help_exit(flag)
+        end.to(output(/Usage: x/).to_stdout)
+      end
+    end
   end
 end

--- a/spec/cycle_keys_spec.rb
+++ b/spec/cycle_keys_spec.rb
@@ -223,6 +223,15 @@ RSpec.describe(CycleKeys) do
       expect { parse_cycle_keys_options(%w[--profile dev]) }
         .to(raise_error(OptionParser::MissingArgument, /username/))
     end
+
+    %w[-h --help].each do |flag|
+      it "exits 0 for #{flag}", :aggregate_failures do
+        expect do
+          expect { parse_cycle_keys_options([flag]) }
+            .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+        end.to(output.to_stdout)
+      end
+    end
   end
 
   describe '#run_cycle_keys' do

--- a/spec/deploy_spec.rb
+++ b/spec/deploy_spec.rb
@@ -791,6 +791,15 @@ RSpec.describe(Deploy) do
       expect { parse_deploy_options(%w[--environment beta1 --instance api]) }
         .to(raise_error(OptionParser::MissingArgument, /profile/))
     end
+
+    %w[-h --help].each do |flag|
+      it "exits 0 for #{flag}", :aggregate_failures do
+        expect do
+          expect { parse_deploy_options([flag]) }
+            .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+        end.to(output.to_stdout)
+      end
+    end
   end
 
   describe '#warm_up_after_scale_up' do

--- a/spec/encrypt_logs_spec.rb
+++ b/spec/encrypt_logs_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe(EncryptLogs) do
       expect { parse_encrypt_logs_options(%w[--profile dev]) }
         .to(raise_error(OptionParser::MissingArgument, /retention_in_days/))
     end
+
+    it 'derives the help banner from the program basename, not a nonexistent encrypt_logs.rb', :aggregate_failures do
+      output = help_output_with_program_name('/usr/local/bin/encrypt-logs') { parse_encrypt_logs_options(%w[--help]) }
+      expect(output).to(include('Usage: encrypt-logs options'))
+      expect(output).not_to(include('encrypt_logs'))
+    end
   end
 
   describe '#run_encrypt_logs' do

--- a/spec/encrypt_logs_spec.rb
+++ b/spec/encrypt_logs_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe(EncryptLogs) do
       expect { parse_encrypt_logs_options(%w[--profile dev]) }
         .to(raise_error(OptionParser::MissingArgument, /retention_in_days/))
     end
+
+    %w[-h --help].each do |flag|
+      it "exits 0 for #{flag}", :aggregate_failures do
+        expect do
+          expect { parse_encrypt_logs_options([flag]) }
+            .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(0)) })
+        end.to(output.to_stdout)
+      end
+    end
   end
 
   describe '#run_encrypt_logs' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,33 @@ require_relative '../deploy'
 require_relative '../encrypt-logs'
 require_relative '../lib/cli_main'
 
+# Captures everything written to $stdout while the block runs and returns it as
+# a String, restoring $stdout even when the block raises (e.g. SystemExit).
+def capture_stdout
+  original = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = original
+end
+
+# Runs the given block with $PROGRAM_NAME temporarily set to program_name,
+# capturing and returning whatever it writes to $stdout. The block is expected
+# to terminate via SystemExit (as --help handlers do), which is swallowed.
+def help_output_with_program_name(program_name)
+  original_program_name = $PROGRAM_NAME
+  $PROGRAM_NAME = program_name
+
+  capture_stdout do
+    yield
+  rescue SystemExit
+    # --help prints the banner then exits; swallow it so we can assert on output
+  end
+ensure
+  $PROGRAM_NAME = original_program_name
+end
+
 RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
   config.disable_monkey_patching!

--- a/ssm-jump.install.bat
+++ b/ssm-jump.install.bat
@@ -8,6 +8,14 @@ SET /P SHORTCUT_NAME=Enter desktop shortcut name (e.g. my-project-prod):
 
 IF "%SSM_DOCUMENT%"=="" SET SSM_DOCUMENT=AWS-StartPortForwardingSessionToRemoteHost
 
+IF "%SHORTCUT_NAME%"=="" (
+	ECHO .
+	ECHO Desktop shortcut name cannot be empty. Exiting.
+	ECHO .
+	PAUSE
+	EXIT /B 1
+)
+
 ECHO Install AWS CLI and session manager
 winget install --exact --id Amazon.AWSCLI --accept-package-agreements --accept-source-agreements
 winget install --exact --id Amazon.SessionManagerPlugin
@@ -53,6 +61,6 @@ curl.exe -SL --fail --progress-bar https://raw.githubusercontent.com/Cloud-Offic
 ECHO Generate connect helper on desktop
 SET CMD_COMMON="C:\Program Files\Git\bin\bash.exe" "%USERPROFILE%\.ssm-jump\ssm-jump.sh" --profile %AWS_PROFILE% --document %SSM_DOCUMENT%
 CD "%USERPROFILE%\Desktop"
-IF NOT EXIST %SHORTCUT_NAME%.bat ECHO %CMD_COMMON% %AWS_INSTANCE% --forward %FORWARD_HOST% >%SHORTCUT_NAME%.bat
+IF NOT EXIST "%SHORTCUT_NAME%.bat" ECHO %CMD_COMMON% "%AWS_INSTANCE%" --forward "%FORWARD_HOST%" >"%SHORTCUT_NAME%.bat"
 
 PAUSE

--- a/tests/ssm_jump_install.bats
+++ b/tests/ssm_jump_install.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+
+setup() {
+  INSTALLER="${BATS_TEST_DIRNAME}/../ssm-jump.install.bat"
+}
+
+# cmd.exe is not available on the Linux/macOS CI runners, so these tests assert
+# the generated batch script is written defensively (quoted expansions and
+# non-empty input validation) via static checks (see issue #509).
+
+@test "validates SHORTCUT_NAME is non-empty before use" {
+  # The empty check must appear before the shortcut is written to disk.
+  guard_line="$(grep -niE 'IF[[:space:]]+"%SHORTCUT_NAME%"==""' "${INSTALLER}" | head -n 1 | cut -d: -f1)"
+  [ -n "${guard_line}" ]
+  use_line="$(grep -niE 'EXIST[[:space:]]+"%SHORTCUT_NAME%\.bat"' "${INSTALLER}" | head -n 1 | cut -d: -f1)"
+  [ -n "${use_line}" ]
+  [ "${guard_line}" -lt "${use_line}" ]
+}
+
+@test "rejects an empty SHORTCUT_NAME with a clear message and non-zero exit" {
+  grep -qiE 'Desktop shortcut name cannot be empty' "${INSTALLER}"
+  grep -qiE 'EXIT[[:space:]]+/B[[:space:]]+1' "${INSTALLER}"
+}
+
+@test "quotes %SHORTCUT_NAME% in the IF EXIST test" {
+  grep -qiE 'IF[[:space:]]+NOT[[:space:]]+EXIST[[:space:]]+"%SHORTCUT_NAME%\.bat"' "${INSTALLER}"
+}
+
+@test "quotes %SHORTCUT_NAME% in the redirection target" {
+  grep -qiE '>"%SHORTCUT_NAME%\.bat"' "${INSTALLER}"
+}
+
+@test "does not redirect into an unquoted %SHORTCUT_NAME%.bat target" {
+  ! grep -qiE '>[[:space:]]*%SHORTCUT_NAME%\.bat' "${INSTALLER}"
+}
+
+@test "does not use an unquoted %SHORTCUT_NAME% in the IF EXIST test" {
+  ! grep -qiE 'EXIST[[:space:]]+%SHORTCUT_NAME%\.bat' "${INSTALLER}"
+}
+
+@test "quotes %AWS_INSTANCE% in the generated helper" {
+  grep -qiE '"%AWS_INSTANCE%"' "${INSTALLER}"
+}
+
+@test "quotes %FORWARD_HOST% in the generated helper" {
+  grep -qiE '"%FORWARD_HOST%"' "${INSTALLER}"
+}


### PR DESCRIPTION
## Summary

Batches five low-severity code-review findings across the CLI tools into one review. Most center on the Ruby CLIs' help/usage behavior; the rest are a Windows-installer hardening fix, an architecture-doc gap, and a misleading comment. #505/#506/#507 overlapped on `encrypt-logs.rb` and `cycle-keys.rb` and were reconciled into a single branch.

**Key changes:**

- **#505** — Centralized `-h`/`--help` into `CliMain.parse_options!` so every Ruby CLI prints usage and exits **0** (an explicitly requested help is success). `cycle-keys.rb` and `encrypt-logs.rb` previously exited 1; `deploy.rb` already exited 0. Removed the three per-CLI handlers to prevent future drift. Regression specs assert exit 0 for `CliMain` and each CLI (`spec/cli_main_spec.rb`, `spec/cycle_keys_spec.rb`, `spec/deploy_spec.rb`, `spec/encrypt_logs_spec.rb`).
- **#506** — Reworded the misleading `KEY_AGE_DAYS_THRESHOLD` comment in `cycle-keys.rb`: AWS does **not** auto-rotate/disable IAM keys at 90 days; 90 is the CIS / `access-keys-rotated` compliance recommendation, and we rotate at 80 to leave a cron buffer. Comment-only.
- **#507** — `encrypt-logs.rb` usage banner is now derived from `File.basename($PROGRAM_NAME)` instead of the nonexistent underscore name `encrypt_logs.rb`, so it can never drift from the installed command. Added a regression spec and reusable `capture_stdout` / `help_output_with_program_name` helpers in `spec/spec_helper.rb`.
- **#508** — Documented the `ssm-jump.install.bat` software unit in `docs/architecture.md` (purpose, winget installs, AWS auth check, Desktop-shortcut generation, external deps). Docs-only.
- **#509** — Quoted `%SHORTCUT_NAME%` / `%AWS_INSTANCE%` / `%FORWARD_HOST%` in `ssm-jump.install.bat` and added non-empty validation for `SHORTCUT_NAME`, so names containing spaces produce a valid desktop helper and empty input is rejected with a clear message. Added `tests/ssm_jump_install.bats`.

**Reconciliation:** `encrypt-logs.rb` keeps #507's derived banner **and** drops #505's local `-h` handler; both new `encrypt_logs_spec.rb` test blocks are kept; `cycle-keys.rb` carries both #506's comment and #505's handler removal.

**Testing notes (no-execution cases, stated explicitly):**
- **#509** — the `.bat` is a Windows `cmd.exe` script that cannot execute on the Linux/macOS CI runners, so `tests/ssm_jump_install.bats` asserts the fixed content via static `grep` checks (matching the existing `tests/dockerfile.bats` precedent). The 8 new tests fail before the fix and pass after.
- **#506** — comment-only change; no behavior altered (validated with `ruby -c`).

Verification: `bundle exec rspec` 201 examples, 0 failures; `bats tests/` 55 tests, 0 failures; RuboCop clean; `cycle-keys.rb -h`, `encrypt-logs.rb -h`, `deploy.rb -h` all exit 0 on the real binaries.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [x] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [x] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified

Fixes #509
Closes #508
Closes #507
Closes #506
Closes #505