### PR TITLE
Bump actions/checkout to v7 in auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: "${{github.event.pull_request.base.sha}}"
     - name: Check if PR author is a code owner


### PR DESCRIPTION
## Summary

Updates the `actions/checkout` action in the auto-approve GitHub Actions workflow from `v6` to `v7` to stay current with the latest major version.

**Key changes:**

- Bump `actions/checkout@v6` to `actions/checkout@v7` in `.github/workflows/auto-approve.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: CI workflow action version bump; validated by CI execution
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified