### PR TITLE
Bump rubocop-capybara to 3.0.0

### DIFF
--- a/.soup.json
+++ b/.soup.json
@@ -590,7 +590,7 @@
   "rubocop-capybara": {
     "language": "Ruby",
     "package": "rubocop-capybara",
-    "version": "2.23.0",
+    "version": "3.0.0",
     "license": "MIT",
     "description": "Code style checking for Capybara test files (RSpec, Cucumber, Minitest).",
     "website": "https://github.com/rubocop/rubocop-capybara",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.23.0)
+    rubocop-capybara (3.0.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.81)
     rubocop-graphql (1.6.0)

--- a/docs/soup.md
+++ b/docs/soup.md
@@ -51,7 +51,7 @@
 | Ruby | rspec-support | 3.13.7 | MIT | Support utilities for RSpec gems | <https://rspec.info> | 2026-05-22 | Low | Dependency | Dependency |
 | Ruby | rubocop | 1.88.0 | MIT | RuboCop is a Ruby code style checking and code formatting tool. | <https://rubocop.org/> | 2026-05-22 | Low | Ruby linter | Most popular gem on rubygems |
 | Ruby | rubocop-ast | 1.49.1 | MIT | RuboCop's Node and NodePattern classes. | <https://www.rubocop.org/> | 2026-05-22 | Low | Dependency | Dependency |
-| Ruby | rubocop-capybara | 2.23.0 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-05-22 | Low | Ruby linter | Most popular gem |
+| Ruby | rubocop-capybara | 3.0.0 | MIT | Code style checking for Capybara test files (RSpec, Cucumber, Minitest). | <https://github.com/rubocop/rubocop-capybara> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-graphql | 1.6.0 | MIT | A collection of RuboCop cops to improve GraphQL-related code | <https://github.com/DmitryTsepelev/rubocop-graphql> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-minitest | 0.39.1 | MIT | Automatic Minitest code style checking tool. | <https://docs.rubocop.org/rubocop-minitest/> | 2026-05-22 | Low | Ruby linter | Most popular gem |
 | Ruby | rubocop-performance | 1.26.1 | MIT | A collection of RuboCop cops to check for performance optimizations | <https://docs.rubocop.org/rubocop-performance/> | 2026-05-22 | Low | A collection of RuboCop cops to check for performance optimizations in Ruby code | Most popular gem |


### PR DESCRIPTION
## Summary

Updates the `rubocop-capybara` development dependency from 2.23.0 to 3.0.0 and regenerates the SOUP records to match the new version.

**Key changes:**

- Bump `rubocop-capybara` from 2.23.0 to 3.0.0 in `Gemfile.lock`
- Regenerate `.soup.json` and `docs/soup.md` to reflect the updated dependency version

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency lockfile bump with no behavior change
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [x] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified